### PR TITLE
fix(GVL_Variables): the pytmc attribute associated with g_FastFaultOutput2 had a hardcoded prefix and was routed to the same pv as g_FastFaultOutputK2;

### DIFF
--- a/plc/plc-kfe-vac/plc-kfe-vac.tsproj
+++ b/plc/plc-kfe-vac/plc-kfe-vac.tsproj
@@ -89,14 +89,6 @@
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{F1C07B37-2D70-463E-B9ED-92089788D29C}" Namespace="Tc2_System" AutoDeleteType="true">T_AmsNetIdArr</Name>
-			<Comment>
-				<![CDATA[ TwinCAT AMS netID address bytes. ]]>
-			</Comment>
-			<BitSize>48</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
-		</DataType>
-		<DataType>
 			<Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
 			<BitSize>64</BitSize>
 			<SubItem>
@@ -398,6 +390,14 @@
 			</Hides>
 		</DataType>
 		<DataType>
+			<Name GUID="{F1C07B37-2D70-463E-B9ED-92089788D29C}" Namespace="Tc2_System" AutoDeleteType="true">T_AmsNetIdArr</Name>
+			<Comment>
+				<![CDATA[ TwinCAT AMS netID address bytes. ]]>
+			</Comment>
+			<BitSize>48</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
+		</DataType>
+		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000001}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..0] OF BIT</Name>
 			<BitSize>1</BitSize>
 			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
@@ -650,6 +650,13 @@
 					<Vars VarGrpType="1">
 						<Name>PlcTask Inputs</Name>
 						<Var>
+							<Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
+							<Comment>
+								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
+							</Comment>
+							<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+						</Var>
+						<Var>
 							<Name>LCLS_Vacuum.Global_Variables.g_stSystem.I_EcatMaster1</Name>
 							<Comment>
 								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
@@ -659,55 +666,6 @@
 						<Var>
 							<Name>PRG_DIAGNOSTIC.simHeartbeat</Name>
 							<Type>UINT</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.wFrmXWcState</Name>
-							<Comment>
-								<![CDATA[ link to task related ethercat frame state (Frm1WcState)]]>
-							</Comment>
-							<Type>WORD</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCount</Name>
-							<Comment>
-								<![CDATA[ link to SlaveCount of EtherCAT Master (Inputs)]]>
-							</Comment>
-							<Type>UINT</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDevState</Name>
-							<Comment>
-								<![CDATA[ link to DevState of EtherCAT Master (Inputs)]]>
-							</Comment>
-							<Type>UINT</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDeviceId</Name>
-							<Comment>
-								<![CDATA[ link to DevID of EtherCAT Master (InfoData)]]>
-							</Comment>
-							<Type>UINT</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.arrEcMasterNetId</Name>
-							<Comment>
-								<![CDATA[ link to NetID of EtherCAT Master (InfoData)]]>
-							</Comment>
-							<Type GUID="{F1C07B37-2D70-463E-B9ED-92089788D29C}" Namespace="Tc2_System">T_AmsNetIdArr</Type>
-						</Var>
-						<Var>
-							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCountCfg</Name>
-							<Comment>
-								<![CDATA[ link to CfgSlaveCount of EtherCAT Master (InfoData)]]>
-							</Comment>
-							<Type>UINT</Type>
-						</Var>
-						<Var>
-							<Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
-							<Comment>
-								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
-							</Comment>
-							<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
 						</Var>
 						<Var>
 							<Name>PRG_PMPS.fbArbiterIO.i_stCurrentBP</Name>
@@ -1475,27 +1433,51 @@
 							</Comment>
 							<Type>BOOL</Type>
 						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.wFrmXWcState</Name>
+							<Comment>
+								<![CDATA[ link to task related ethercat frame state (Frm1WcState)]]>
+							</Comment>
+							<Type>WORD</Type>
+						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCount</Name>
+							<Comment>
+								<![CDATA[ link to SlaveCount of EtherCAT Master (Inputs)]]>
+							</Comment>
+							<Type>UINT</Type>
+						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDevState</Name>
+							<Comment>
+								<![CDATA[ link to DevState of EtherCAT Master (Inputs)]]>
+							</Comment>
+							<Type>UINT</Type>
+						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDeviceId</Name>
+							<Comment>
+								<![CDATA[ link to DevID of EtherCAT Master (InfoData)]]>
+							</Comment>
+							<Type>UINT</Type>
+						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.arrEcMasterNetId</Name>
+							<Comment>
+								<![CDATA[ link to NetID of EtherCAT Master (InfoData)]]>
+							</Comment>
+							<Type GUID="{F1C07B37-2D70-463E-B9ED-92089788D29C}" Namespace="Tc2_System">T_AmsNetIdArr</Type>
+						</Var>
+						<Var>
+							<Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCountCfg</Name>
+							<Comment>
+								<![CDATA[ link to CfgSlaveCount of EtherCAT Master (InfoData)]]>
+							</Comment>
+							<Type>UINT</Type>
+						</Var>
 					</Vars>
 					<Vars VarGrpType="2">
 						<Name>PlcTask Outputs</Name>
-						<Var>
-							<Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1.q_xTREATY_VGC_STATUS</Name>
-							<Type>BOOL</Type>
-						</Var>
-						<Var>
-							<Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper.q_xILK_OK_DO</Name>
-							<Comment>
-								<![CDATA[ Send the signal to indicate that the interlock pressure has been met.]]>
-							</Comment>
-							<Type>BOOL</Type>
-						</Var>
-						<Var>
-							<Name>GVL_VAC_INTF.fb_TMO_ILK_Lower.q_xILK_OK_DO</Name>
-							<Comment>
-								<![CDATA[ Send the signal to indicate that the interlock pressure has been met.]]>
-							</Comment>
-							<Type>BOOL</Type>
-						</Var>
 						<Var>
 							<Name>PRG_PMPS.fbArbiterIO.q_stRequestedBP</Name>
 							<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
@@ -1929,6 +1911,24 @@
 							<Name>GVL_SXR_VAC.fb_SL1K0_PIP_1.q_xHVEna_DO</Name>
 							<Comment>
 								<![CDATA[ Enable High Voltage when TRUE]]>
+							</Comment>
+							<Type>BOOL</Type>
+						</Var>
+						<Var>
+							<Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1.q_xTREATY_VGC_STATUS</Name>
+							<Type>BOOL</Type>
+						</Var>
+						<Var>
+							<Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper.q_xILK_OK_DO</Name>
+							<Comment>
+								<![CDATA[ Send the signal to indicate that the interlock pressure has been met.]]>
+							</Comment>
+							<Type>BOOL</Type>
+						</Var>
+						<Var>
+							<Name>GVL_VAC_INTF.fb_TMO_ILK_Lower.q_xILK_OK_DO</Name>
+							<Comment>
+								<![CDATA[ Send the signal to indicate that the interlock pressure has been met.]]>
 							</Comment>
 							<Type>BOOL</Type>
 						</Var>
@@ -23394,7 +23394,6 @@ Bit1: Value bigger/equal Limit2]]>
 				<Link VarA="PlcTask Inputs^GVL_Variables.fbEcatDiagWrapper.nEcMasterDeviceId" VarB="InfoData^DevId" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCount" VarB="Inputs^SlaveCount" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCountCfg" VarB="InfoData^CfgSlaveCount" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_Variables.fbEcatDiagWrapper.wFrmXWcState" VarB="Inputs^Frm1WcState" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^=+-EK1100_01_00^=+-EL2798_01_02">
 				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1.q_xHV_DIS" VarB="Channel 2^GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1.q_xHV_DIS"/>
@@ -23643,9 +23642,6 @@ Bit1: Value bigger/equal Limit2]]>
 				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1.q_xOPN_DO" VarB="Channel 4^Output" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIPC^plc_kfe_vac^plc_kfe_vac Instance">
-				<Link VarA="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xOPN_SW" VarB="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOPN_SW" AutoLink="true"/>
-				<Link VarA="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xOverrideOpen" VarB="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOverrideOpen" AutoLink="true"/>
-				<Link VarA="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xVAC_FAULT_Reset" VarB="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xVAC_FAULT_Reset" AutoLink="true"/>
 				<Link VarA="FSV_task Outputs^GVL_VFS.fb_TV2K0_VFS_1.q_xTrigger" VarB="PlcTask Inputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xTrigger" AutoLink="true"/>
 				<Link VarA="FSV_task Outputs^GVL_VFS.fb_TV2K0_VFS_1.q_xVFS_Closed" VarB="PlcTask Inputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVFS_Closed" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_eVFS_State" VarB="FSV_task Outputs^GVL_VFS.fb_TV2K0_VFS_1.q_eVFS_State" AutoLink="true"/>
@@ -23653,8 +23649,11 @@ Bit1: Value bigger/equal Limit2]]>
 				<Link VarA="PlcTask Inputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVAC_FAULT_OK" VarB="FSV_task Outputs^GVL_VFS.fb_TV2K0_VFS_1.q_xVAC_FAULT_OK" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVFS_Open" VarB="FSV_task Outputs^GVL_VFS.fb_TV2K0_VFS_1.q_xVFS_Open" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xCLS_SW" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xCLS_SW" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOPN_SW" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xOPN_SW" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOverrideMode" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xOverrideMode" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOverrideOpen" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xOverrideOpen" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xPRESS_OK" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xPress_OK" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xVAC_FAULT_Reset" VarB="FSV_task Inputs^GVL_VFS.fb_TV2K0_VFS_1.i_xVAC_FAULT_Reset" AutoLink="true"/>
 			</OwnerB>
 		</OwnerA>
 		<OwnerA Name="TIPC^plc_kfe_vac_sim^plc_kfe_vac_sim Instance">

--- a/plc/plc-kfe-vac/plc_kfe_vac/GVLs/GVL_Variables.TcGVL
+++ b/plc/plc-kfe-vac/plc_kfe_vac/GVLs/GVL_Variables.TcGVL
@@ -46,7 +46,7 @@ g_FastFaultOutputK4  :   FB_HardwareFFOutput :=(i_sNetID:='172.21.92.73.1.1');
 g_FastFaultOutputAll  :   FB_HardwareFFOutput :=(i_sNetID:='172.21.92.73.1.1');
 
 {attribute 'pytmc' := '
-    pv: PLC:KFE:VAC:K0:FFO:02
+    pv: @(PREFIX)FFO:05
 '}
 {attribute 'TcLinkTo' := '.q_xFastFaultOut:=TIIB[PMPS_FFO (EL2202)]^Channel 2^Output'}
 g_FastFaultOutput2  :	FB_HardwareFFOutput :=(i_sNetID:='172.21.92.73.1.1');	//FFO for Fast Shutter Valves upstream of ST1L0_XTES

--- a/plc/plc-kfe-vac/plc_kfe_vac/plc_kfe_vac.tmc
+++ b/plc/plc-kfe-vac/plc_kfe_vac/plc_kfe_vac.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CD5195BD-4A33-C345-F688-B4F505F08337}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{07440C67-E23C-808A-AD56-12FF4676713A}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
@@ -15,439 +15,6 @@
         <Enum>1</Enum>
         <Comment> 0 for octal type, 0x, 0X for hex else none  </Comment>
       </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
-      <BitSize>2048</BitSize>
-      <SubItem>
-        <Name>ObjId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TaskCnt</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OnlineChangeCnt</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Flags</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AdsPort</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>BootDataLoaded</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OldBootData</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AppTimestamp</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000004C}">DT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>KeepOutputsOnBP</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ShutdownInProgress</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LicensesPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>BSODOccured</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LoggedIn</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TComSrvPtr</Name>
-        <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
-        <BitSize X64="64">32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcComInterface</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>AppName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ProjectName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <Hides>
-        <Hide GUID="{D91E046A-A488-4D27-8D43-0F3C40ED5081}"/>
-        <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
-        <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
-        <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_KindOfTask</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>_implicit_cyclic</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_event</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_external</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_freewheeling</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_Jitter_Distribution</Name>
-      <BitSize>48</BitSize>
-      <SubItem>
-        <Name>wRangeMax</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wCountJitterNeg</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wCountJitterPos</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>hide</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_Task_Info</Name>
-      <BitSize>704</BitSize>
-      <SubItem>
-        <Name>dwVersion</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pszName</Name>
-        <Type PointerTo="1">STRING(80)</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPriority</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>KindOf</Name>
-        <Type>_Implicit_KindOfTask</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bWatchdog</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bProfilingTask</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>104</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwEventFunctionPointer</Name>
-        <Type PointerTo="1">BYTE</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pszExternalEvent</Name>
-        <Type PointerTo="1">STRING(80)</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwTaskEntryFunctionPointer</Name>
-        <Type PointerTo="1">BYTE</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwWatchdogSensitivity</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwInterval</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwWatchdogTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwLastCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwAverageCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwMaxCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwMinCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitterMin</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitterMax</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwCycleCount</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wTaskStatus</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wNumOfJitterDistributions</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>592</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pJitterDistribution</Name>
-        <Type PointerTo="1">_Implicit_Jitter_Distribution</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bWithinSPSTimeSlicing</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>byDummy</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bShouldBlock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bActive</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwIECCycleCount</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>672</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>hide</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
-      <BitSize>16</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Verbose</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Info</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Warning</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Error</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Critical</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>plcAttribute_qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>plcAttribute_strict</Name>
-        </Property>
-      </Properties>
-      <Hides>
-        <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
-        <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>uuidEventClass</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEventId</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eSeverity</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_System">T_MaxString</Name>
@@ -4236,6 +3803,43 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Verbose</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Info</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Warning</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Error</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Critical</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+        <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General">E_Subsystem</Name>
       <BitSize>16</BitSize>
       <BaseType>WORD</BaseType>
@@ -4325,31 +3929,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81375028</GetCodeOffs>
+        <GetCodeOffs>81377584</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81375064</GetCodeOffs>
+        <GetCodeOffs>81377620</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81375072</GetCodeOffs>
+        <GetCodeOffs>81377628</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81375052</GetCodeOffs>
+        <GetCodeOffs>81377608</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81375068</GetCodeOffs>
+        <GetCodeOffs>81377624</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -4777,6 +4381,28 @@
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>uuidEventClass</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEventId</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Name>
@@ -5566,15 +5192,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81374968</GetCodeOffs>
-        <SetCodeOffs>81374992</SetCodeOffs>
+        <GetCodeOffs>81377524</GetCodeOffs>
+        <SetCodeOffs>81377548</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81375008</GetCodeOffs>
-        <SetCodeOffs>81375020</SetCodeOffs>
+        <GetCodeOffs>81377564</GetCodeOffs>
+        <SetCodeOffs>81377576</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
@@ -5820,37 +5446,37 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>81375120</GetCodeOffs>
+        <GetCodeOffs>81377676</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81375100</GetCodeOffs>
+        <GetCodeOffs>81377656</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81375188</GetCodeOffs>
+        <GetCodeOffs>81377744</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81375192</GetCodeOffs>
+        <GetCodeOffs>81377748</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81375148</GetCodeOffs>
+        <GetCodeOffs>81377704</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81375196</GetCodeOffs>
+        <GetCodeOffs>81377752</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -6449,7 +6075,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>81375220</GetCodeOffs>
+        <GetCodeOffs>81377776</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -8952,6 +8578,455 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
+      <BitSize>2048</BitSize>
+      <SubItem>
+        <Name>ObjId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TaskCnt</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OnlineChangeCnt</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Flags</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AdsPort</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BootDataLoaded</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OldBootData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AppTimestamp</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000004C}">DT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>KeepOutputsOnBP</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ShutdownInProgress</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LicensesPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BSODOccured</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LoggedIn</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TComSrvPtr</Name>
+        <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
+        <BitSize X64="64">32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcComInterface</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>AppName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ProjectName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{D91E046A-A488-4D27-8D43-0F3C40ED5081}"/>
+        <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
+        <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
+        <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_KindOfTask</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>_implicit_cyclic</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_event</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_external</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_freewheeling</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_Jitter_Distribution</Name>
+      <BitSize>48</BitSize>
+      <SubItem>
+        <Name>wRangeMax</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wCountJitterNeg</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wCountJitterPos</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_Task_Info</Name>
+      <BitSize>704</BitSize>
+      <SubItem>
+        <Name>dwVersion</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pszName</Name>
+        <Type PointerTo="1">STRING(80)</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPriority</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>KindOf</Name>
+        <Type>_Implicit_KindOfTask</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWatchdog</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bProfilingTask</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwEventFunctionPointer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pszExternalEvent</Name>
+        <Type PointerTo="1">STRING(80)</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwTaskEntryFunctionPointer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwWatchdogSensitivity</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwInterval</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwWatchdogTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwLastCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwAverageCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwMaxCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwMinCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitterMin</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitterMax</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwCycleCount</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wTaskStatus</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wNumOfJitterDistributions</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pJitterDistribution</Name>
+        <Type PointerTo="1">_Implicit_Jitter_Distribution</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWithinSPSTimeSlicing</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>byDummy</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bShouldBlock</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bActive</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwIECCycleCount</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+      <BitSize>48</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+      <ArrayInfo>
+        <LBound>0</LBound>
+        <Elements>6</Elements>
+      </ArrayInfo>
+      <Format>
+        <Printf>%d.%d.%d.%d.%d.%d</Printf>
+        <Parameter>[0]</Parameter>
+        <Parameter>[1]</Parameter>
+        <Parameter>[2]</Parameter>
+        <Parameter>[3]</Parameter>
+        <Parameter>[4]</Parameter>
+        <Parameter>[5]</Parameter>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">ST_System</Name>
+      <Comment>Defacto system structure, must be included in all projects</Comment>
+      <BitSize>88</BitSize>
+      <SubItem>
+        <Name>xSwAlmRst</Name>
+        <Type>BOOL</Type>
+        <Comment> Global Alarm Reset - EPICS Command </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xAtVacuum</Name>
+        <Type>BOOL</Type>
+        <Comment> System At Vacuum </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstScan</Name>
+        <Type>BOOL</Type>
+        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>This bit is set when using the override features of the system</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xIOState</Name>
+        <Type>BOOL</Type>
+        <Comment> ECat Bus Health </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>I_EcatMaster1</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+        <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
+        <BitSize>48</BitSize>
+        <BitOffs>40</BitOffs>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
     </DataType>
     <DataType>
       <Name GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}" TcBaseType="true">ST_LibVersion</Name>
@@ -12779,6 +12854,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>FindTestSuiteInstancePath</Name>
@@ -13037,6 +13117,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_BYTE</Name>
@@ -13138,6 +13223,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -13297,6 +13387,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
@@ -13419,6 +13514,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -13560,6 +13660,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -14321,6 +14426,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -14481,6 +14591,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -14583,6 +14698,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -14737,6 +14857,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
@@ -14859,6 +14984,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -15034,6 +15164,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -15316,6 +15451,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -16112,6 +16252,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
@@ -16203,6 +16348,11 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -16618,81 +16768,6 @@ The Fast shutter was tested with PLC task Cycle Base Time 50us with cycle time 0
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-      <BitSize>48</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-      <ArrayInfo>
-        <LBound>0</LBound>
-        <Elements>6</Elements>
-      </ArrayInfo>
-      <Format>
-        <Printf>%d.%d.%d.%d.%d.%d</Printf>
-        <Parameter>[0]</Parameter>
-        <Parameter>[1]</Parameter>
-        <Parameter>[2]</Parameter>
-        <Parameter>[3]</Parameter>
-        <Parameter>[4]</Parameter>
-        <Parameter>[5]</Parameter>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">ST_System</Name>
-      <Comment>Defacto system structure, must be included in all projects</Comment>
-      <BitSize>88</BitSize>
-      <SubItem>
-        <Name>xSwAlmRst</Name>
-        <Type>BOOL</Type>
-        <Comment> Global Alarm Reset - EPICS Command </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xAtVacuum</Name>
-        <Type>BOOL</Type>
-        <Comment> System At Vacuum </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstScan</Name>
-        <Type>BOOL</Type>
-        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>This bit is set when using the override features of the system</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xIOState</Name>
-        <Type>BOOL</Type>
-        <Comment> ECat Bus Health </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>I_EcatMaster1</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-        <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
-        <BitSize>48</BitSize>
-        <BitOffs>40</BitOffs>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_Vacuum">E_PressureState</Name>
@@ -17234,19 +17309,6 @@ These features aren't disabled, they just aren't used, think child/parent classe
       </Hides>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">PE_Ranges</Name>
-      <Comment> Does nothing other than set the gvl for photon energy bitmask to one of two constants, K or L.
- Workaround for compile defines not fully working for libraries at the time of writing this.
- Otherwise I would have just used the compile define in the GVL declaration.</Comment>
-      <BitSize>32</BitSize>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
       <BitSize>64</BitSize>
       <SubItem>
@@ -17277,6 +17339,336 @@ These features aren't disabled, they just aren't used, think child/parent classe
       <Name Namespace="PMPS">ST_PMPS_Attenuator</Name>
       <BitSize>64</BitSize>
       <ExtendsType GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>Width</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment> distance between horizontal slits (x)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Width
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Height</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment> distance between vertical slits (y)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Height
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOK</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <Comment> status of aperture, false if error or in motion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: OK
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_PMPS_Aperture</Name>
+      <BitSize>96</BitSize>
+      <ExtendsType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_BeamParams</Name>
+      <BitSize>1760</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type>REAL</Type>
+        <Comment>  Requested pre-optic attenuation %  </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Transmission
+            io: i
+			field: HOPR 1;
+			field: LOPR 0;
+			field: PREC 2;
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRate</Name>
+        <Type>UDINT</Type>
+        <Comment> Pulse-rate </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Rate
+            io: i
+            field: EGU Hz
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neVRange</Name>
+        <Type>DWORD</Type>
+        <Comment> Photon energy ranges </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: eVRanges
+            io: i
+            field: EGU eV</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neV</Name>
+        <Type>REAL</Type>
+        <Comment> Photon energy  </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PhotonEnergy
+            io: i
+            field: EGU eV</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nBCRange</Name>
+        <Type>WORD</Type>
+        <Comment> Beamclass ranges </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: BeamClassRanges
+            io: i</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nBeamClass</Name>
+        <Type>USINT</Type>
+        <Comment> Beamclass </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: BeamClass
+            io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMachineMode</Name>
+        <Type>USINT</Type>
+        <Comment> Machine Mode </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: MachineMode
+            io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astAttenuators</Name>
+        <Type Namespace="PMPS">ST_PMPS_Attenuator</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Beamline attenuators </Comment>
+        <BitSize>1024</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: AuxAtt
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aVetoDevices</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Stoppers </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>1184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Veto
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astApertures</Name>
+        <Type Namespace="PMPS">ST_PMPS_Aperture</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>4</Elements>
+        </ArrayInfo>
+        <Comment> Apertures </Comment>
+        <BitSize>384</BitSize>
+        <BitOffs>1312</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>[1].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[1].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Apt
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xValidToggle</Name>
+        <Type>BOOL</Type>
+        <Comment> Toggle for watchdog</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xValid</Name>
+        <Type>BOOL</Type>
+        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Valid
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCohortInt</Name>
+        <Type>UDINT</Type>
+        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Cohort
+        io: i
+            field: DESC Cohort inc on each arb cycle
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">PE_Ranges</Name>
+      <Comment> Does nothing other than set the gvl for photon energy bitmask to one of two constants, K or L.
+ Workaround for compile defines not fully working for libraries at the time of writing this.
+ Otherwise I would have just used the compile define in the GVL declaration.</Comment>
+      <BitSize>32</BitSize>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_Vacuum.PMPS.Tc2_MC2">_ST_NCADS_IDXOFFS_AxisParameter</Name>
@@ -19408,6 +19800,6126 @@ These features aren't disabled, they just aren't used, think child/parent classe
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">I_HigherAuthority</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID to remove</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestBP</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID of state requesting beam parameter set</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stReqBP</Name>
+          <Comment>Requested beam params</Comment>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">I_LowerAuthority</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getnLowerAuthorityID</Name>
+        <ReturnType RpcDirection="out">DWORD</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>ElevateRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>HigherAuthority</Name>
+          <Type Namespace="PMPS">I_HigherAuthority</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
+      <BitSize>2464</BitSize>
+      <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
+      <SubItem>
+        <Name>nId</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1760</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: ID
+		io: i
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LiveInTable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Live
+		io: i
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDevName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Device
+		io: i
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">T_HashTableEntry</Name>
+      <Comment> Hash table entry </Comment>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <Comment> Entry key: 32 bit unsigned integer or pointer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>lock</Name>
+        <Type>DWORD</Type>
+        <Comment> Node state flags: Bit 0 &lt;0..1&gt;: 0 = node free, 1 = node in use, other bits reserved </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pNext</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Pointer to next hash table element </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pNextFree</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Pointer to next free element </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pNextGlob</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Pointer to next global element </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">T_HHASHTABLE</Name>
+      <Comment> Hash table object handle </Comment>
+      <BitSize>3488</BitSize>
+      <SubItem>
+        <Name>nCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of used hash table entries </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nFree</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of free hash table entries </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>pEntries</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <Comment> Pointer to table array </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbEntries</Name>
+        <Type>UDINT</Type>
+        <Comment> Byte size of table array </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nElements</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of table/array elements </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbElement</Name>
+        <Type>UDINT</Type>
+        <Comment> Byte size of one array element </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pEntrys</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>101</Elements>
+        </ArrayInfo>
+        <BitSize>3232</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pFreeEntrys</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3424</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pFirstEntry</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3456</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_HashTableCtrl</Name>
+      <Comment> Hash table control function block </Comment>
+      <BitSize>352</BitSize>
+      <SubItem>
+        <Name>hTable</Name>
+        <Type Namespace="Tc2_Utilities" ReferenceTo="true">T_HHASHTABLE</Type>
+        <Comment> Hash table handle variable </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <Comment> Entry key: 32 bit unsigned integer or pointer, used by A_Lookup, A_Remove method, the key.lookup variable is also used by A_Add method </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>putValue</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>putPosPtr</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <Comment> Hash table entry position pointer, used by A_GetNext </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOk</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE = success, FALSE = error </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getValue</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getPosPtr</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <Comment> returned by A_GetFirstEntry, A_GetNextEntry, A_Add, A_Lookup and A_Remove method </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>p</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>n</Name>
+        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nHash</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
+        <Name>A_RemoveAll</Name>
+      </Action>
+      <Action>
+        <Name>A_GetNext</Name>
+      </Action>
+      <Action>
+        <Name>A_GetIndexAtPosPtr</Name>
+      </Action>
+      <Action>
+        <Name>A_Add</Name>
+      </Action>
+      <Action>
+        <Name>A_Remove</Name>
+      </Action>
+      <Action>
+        <Name>A_GetFirst</Name>
+      </Action>
+      <Action>
+        <Name>A_RemoveFirst</Name>
+      </Action>
+      <Action>
+        <Name>A_Lookup</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_BeamParamAssertionPool</Name>
+      <Comment> This function block implements simple database. Data element values are stored in the hash table.  </Comment>
+      <BitSize>214336</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <Comment> Entry key: used by A_Lookup, A_Remove method, the key variable is also used by A_Add method </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>putPosPtr</Name>
+        <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
+        <Comment> Hash table entry position pointer (used by A_Find, A_GetNext, A_GetPrev) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>putValue</Name>
+        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+        <Comment> Hash table entry value (used by A_AddHead, A_AddTail, A_Find )</Comment>
+        <BitSize>2464</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOk</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE = Success, FALSE = Failed </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2560</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getPosPtr</Name>
+        <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
+        <Comment> Returned hash table entry position pointer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2592</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getValue</Name>
+        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+        <Comment> Returned hash table entry value </Comment>
+        <BitSize>2464</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Hash table size (number of used entries, used by A_Count) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>5088</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>epicsDataPool</Name>
+        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>20</Elements>
+        </ArrayInfo>
+        <Comment> Structured data element pool for display in EPICS</Comment>
+        <BitSize>49280</BitSize>
+        <BitOffs>5120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Entry
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>dataPool</Name>
+        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>61</Elements>
+        </ArrayInfo>
+        <Comment> Structured data element pool </Comment>
+        <BitSize>150304</BitSize>
+        <BitOffs>54400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>entries</Name>
+        <Type Namespace="PMPS">T_HashTableEntry</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>61</Elements>
+        </ArrayInfo>
+        <Comment> Max. number of hash table entries. The value of table entry = 32 bit integer (pointer to dataPool-array-entry) </Comment>
+        <BitSize>3904</BitSize>
+        <BitOffs>204704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbTable</Name>
+        <Type Namespace="Tc2_Utilities">FB_HashTableCtrl</Type>
+        <Comment> basic hash table control function block </Comment>
+        <BitSize>352</BitSize>
+        <BitOffs>208608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hTable</Name>
+        <Type Namespace="Tc2_Utilities">T_HHASHTABLE</Type>
+        <Comment> hash table handle </Comment>
+        <BitSize>3488</BitSize>
+        <BitOffs>208960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pRefPtr</Name>
+        <Type Namespace="PMPS" PointerTo="1">ST_BP_ArbInternal</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>212448</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>indexOfElem</Name>
+        <Type>ULINT</Type>
+        <Comment> Integer value (max. size: x86=&gt;32bit, x64=&gt;64bit)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>212480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cstSafeBeam</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> MG </Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>212544</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.nTran</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.neVRange</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nRate</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nBCRange</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
+        <Name>A_Count</Name>
+      </Action>
+      <Action>
+        <Name>DataPoolToEpics</Name>
+      </Action>
+      <Action>
+        <Name>A_Add</Name>
+      </Action>
+      <Action>
+        <Name>A_Remove</Name>
+      </Action>
+      <Action>
+        <Name>A_GetFirst</Name>
+      </Action>
+      <Action>
+        <Name>A_GetNext</Name>
+      </Action>
+      <Action>
+        <Name>A_Lookup</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_check</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_Arbiter</Name>
+      <Comment> FB Arbiter
+A. Wallace 2020-6-26
+
+The arbiter primary objectives are:
+- Provide a simple interface for devices to request beam parameter sets
+- Provide a way for devices to verify their BPS is active in the arbiter
+- Provide a way for devices remove their requests from evaluation
+- Evaluate all active beam parameter requests registered with the aribiter,
+to determine the safest combination of all sets, provide this set as an output.
+- Do all of this with minimal overhead
+
+To these ends, the arbiter uses a hash-table, the rows being a state-id as the key, and a corresponding
+ beam parameter set to be evaluated against all the other sets (or rows), in the table.
+ 
+The hash table can be thought of as an array on steriods, they are worth reading about, suffice to say
+the hash table will tell you when you reach the end of all the entries, and enables us to find entries quickly.
+
+These features efficiently address the addition, removal, and verification of beam parameter sets listed in the above requirements.
+</Comment>
+      <BitSize>474624</BitSize>
+      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
+      <Implements Namespace="PMPS">I_LowerAuthority</Implements>
+      <SubItem>
+        <Name>nRequestsCount</Name>
+        <Type>UDINT</Type>
+        <Comment> How many requests are currently in the arbiter</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbBPAssertionPool</Name>
+        <Type Namespace="PMPS">FB_BeamParamAssertionPool</Type>
+        <Comment>Table of active beam parameter assertions</Comment>
+        <BitSize>214336</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: AP
+        io: i
+        field: DESC Assertion Pool
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xRequestMade</Name>
+        <Type>BOOL</Type>
+        <Comment> Arbiter has confirmed its request has made it into the beam parameter request    </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>214464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nArbiterID</Name>
+        <Type>UDINT</Type>
+        <Comment> Arbiter ID, used for making higher-level BP requests</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ArbiterID
+        io: i
+        field: DESC Arbiter ID for elev. req.
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nNextCohort</Name>
+        <Type>UDINT</Type>
+        <Comment> The cohort ID any new requests will adopt, will become ReqInProgCohort at the start of the next acknowledgement cycle</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214528</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nAckInProgCohort</Name>
+        <Type>UDINT</Type>
+        <Comment> The cohort ID currently being acknowledged, will become nActiveCohort after acknowledgement from HA</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214560</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveCohort</Name>
+        <Type>UDINT</Type>
+        <Comment> Requests with cohorts &lt;= to this value will be considered active in CheckRequest</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214592</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: CohortCounter
+        io: i
+        field: DESC Intrnl cohort counter
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bStartNewAckRequest</Name>
+        <Type>BOOL</Type>
+        <Comment> Set by an add or remove method call, triggers an ack cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>214624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAckInProgress</Name>
+        <Type>BOOL</Type>
+        <Comment> Set by ElevateReq when there is a new ack request and reset when the ack cycle is complete</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>214632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>idTransmission</Name>
+        <Type>DWORD</Type>
+        <Comment> ID of BP limiting transmission</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>idRate</Name>
+        <Type>DWORD</Type>
+        <Comment> ID of BP limiting rate</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>214688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>214720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sArbName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>216768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InfoStringFmtr</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <BitSize>7840</BitSize>
+        <BitOffs>218816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bVerbose</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>226656</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>q_stBeamParams</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment>Updated on each cycle of the arbiter FB with the current arbitrated beam parameter set</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>226688</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ArbitratedBP
+        io: i
+        field: DESC Arbitrated BP
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xStateIDFound</Name>
+        <Type>BOOL</Type>
+        <Comment>Set true if a state-id is found in the assertion pool after calling A_VerifyAssertion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>228448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__GETARBITRATEDBP__XFIRSTPASS</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>228456</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>__GETARBITRATEDBP__FBGETCURTASKIDX</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>228480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__GETARBITRATEDBP__LASTCYCLECOUNT</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>228608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__GETARBITRATEDBP__FBLOGMESSAGE</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>81984</BitSize>
+        <BitOffs>228672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__ADDREQUEST__FBLOG</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>81984</BitSize>
+        <BitOffs>310656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__REMOVEREQUEST__FBLOG</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>81984</BitSize>
+        <BitOffs>392640</BitOffs>
+      </SubItem>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ElevateRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>HigherAuthority</Name>
+          <Type Namespace="PMPS">I_HigherAuthority</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArbitratedBP</Name>
+        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
+        <ReturnBitSize>1760</ReturnBitSize>
+        <Local>
+          <Name>getPosPtr</Name>
+          <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>getBPStructInt</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+        <Local>
+          <Name>stOutputBP</Name>
+          <Comment>Holding struct for arbitration process</Comment>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+        <Local>
+          <Name>xFirstPass</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__GETARBITRATEDBP__XFIRSTPASS</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>fbGetCurTaskIdx</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__GETARBITRATEDBP__FBGETCURTASKIDX</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>LastCycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__GETARBITRATEDBP__LASTCYCLECOUNT</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>fbLogMessage</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81984</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__GETARBITRATEDBP__FBLOGMESSAGE</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ArbitrateBP</Name>
+        <ReturnType Namespace="PMPS">ST_BP_ArbInternal</ReturnType>
+        <ReturnBitSize>2464</ReturnBitSize>
+        <Parameter>
+          <Name>stBP1</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stBP2</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Parameter>
+        <Local>
+          <Name>idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>bcBitmask</Name>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__getnLowerAuthorityID</Name>
+        <ReturnType RpcDirection="out">DWORD</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nLowerAuthorityID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AddRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment> Unique ID within aribter for the request. Make sure this is unique for every device + state combination</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stReqBP</Name>
+          <Comment>Requested beam params</Comment>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sDevName</Name>
+          <Comment> Name of the device making the request</Comment>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81984</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__ADDREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqId</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81984</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CheckRequestInPool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestBP</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID of state requesting beam parameter set</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stReqBP</Name>
+          <Comment>Requested beam params</Comment>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
+      <BitSize>1760</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment TxtId="">Requested pre-optic attenuation - 1 is full transmission</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Min>0</Min>
+          <Max>1</Max>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Attenuation
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRate</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <Comment> Pulse-rate </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>120</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Rate
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neVRange</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <Comment> Photon energy ranges </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>4294967295</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: PhotonEnergy
+        io: i</Value>
+          </Property>
+          <Property>
+            <Name>plcAttribute_displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neV</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment TxtId="">Current Photon energy as calculated by the arbiter</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nBCRange</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000004}">WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Min>0</Min>
+          <Max>65535</Max>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nBeamClass</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <Min>0</Min>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nMachineMode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astAttenuators</Name>
+        <Type GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Beamline attenuators </Comment>
+        <BitSize>1024</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: AuxAttenuator
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astApertures</Name>
+        <Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>4</Elements>
+        </ArrayInfo>
+        <BitSize>384</BitSize>
+        <BitOffs>1184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>aVetoDevices</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Stopper statuses </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>1568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: AuxAttenuator
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xValidToggle</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <Comment> Toggle for watchdog</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xValid</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Valid
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCohortInt</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Attenuation
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{ADE62DDD-CAE3-4FE3-BE11-F358D7D0CDD8}"/>
+        <Hide GUID="{729DFDAA-EB68-494E-B247-D86DA3C0AE5E}"/>
+        <Hide GUID="{41059C79-1015-4C2C-AFF4-697A824775D7}"/>
+        <Hide GUID="{80E871EC-0C36-49B0-AD5D-F1F0FB351299}"/>
+        <Hide GUID="{5FC92061-002A-45B0-B954-CD8F28B5CE49}"/>
+        <Hide GUID="{C64C88BE-2BD8-4AC6-ACD6-2A08570B4923}"/>
+        <Hide GUID="{B472A77E-9430-445F-AD24-21E649F6ACD1}"/>
+        <Hide GUID="{559ADF00-CB27-4B7D-8DEA-9DBCF390B12B}"/>
+        <Hide GUID="{E1A510FA-6CE5-40B2-9617-7C29C5B7C692}"/>
+        <Hide GUID="{3F6D5E74-4433-4A11-8ADE-14BBEED361D6}"/>
+        <Hide GUID="{6E597FBD-95E0-4E3A-8361-F15F77CF10FA}"/>
+        <Hide GUID="{5F9FBCD0-8C11-4386-87CB-253F17D55690}"/>
+        <Hide GUID="{5F9FBCD0-8C11-4386-87CB-253F17D55690}"/>
+        <Hide GUID="{F4D82764-2299-4BB7-86C4-99ED0EBA5A76}"/>
+        <Hide GUID="{1E08C18A-0551-4C52-916A-1A7A2B58BA24}"/>
+        <Hide GUID="{1E08C18A-0551-4C52-916A-1A7A2B58BA24}"/>
+        <Hide GUID="{0C6A4924-E177-45F6-9AB0-6F9DB98D3474}"/>
+        <Hide GUID="{7BACB0F9-4BD8-4ADE-B8B1-2D069E1D0190}"/>
+        <Hide GUID="{C338245C-50EC-4E6D-B363-9DA04BB5DFA5}"/>
+        <Hide GUID="{0E623A01-D6F4-41DD-A8F2-FBC77EE11035}"/>
+        <Hide GUID="{B8136069-15B2-4545-8E40-00504F2F580D}"/>
+        <Hide GUID="{4A38F9D3-765E-4C94-9AAB-7EB5DFA13820}"/>
+        <Hide GUID="{C9AB5DB1-1B57-42EF-8E17-FBE97768475C}"/>
+        <Hide GUID="{43851ABC-CF8A-4AF9-A768-E27D209879D8}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_VetoArbiter</Name>
+      <BitSize>27168</BitSize>
+      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
+      <SubItem>
+        <Name>bVeto</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge clears request, hold true to veto continuously, falling edge restores request</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>HigherAuthority</Name>
+        <Type Namespace="PMPS">I_HigherAuthority</Type>
+        <Comment> Typically connected to a higher-level arbiter.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LowerAuthority</Name>
+        <Type Namespace="PMPS">I_LowerAuthority</Type>
+        <Comment> Lower authority to be vetoed</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FFO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> This should be the FFO upstream of the veto device</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffKeepItSecretKeepItSafe</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_xAutoReset</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Holds beam off until request is back in arbitration</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>200</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_xVetoable</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stStandbyBP</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>25280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtVeto</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>27040</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftVeto</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>27104</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestBP</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID of state requesting beam parameter set</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stReqBP</Name>
+          <Comment>Requested beam params</Comment>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID to remove</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_SubSysToArbiter_IO</Name>
+      <Comment> Use on a subsystem PLC to request from the arbiter
+ Run at the top of your cycle to receive the latest BP</Comment>
+      <BitSize>138752</BitSize>
+      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
+      <SubItem>
+        <Name>Reset</Name>
+        <Type>BOOL</Type>
+        <Comment> Fast fault reset</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>72</BitOffs>
+        <Default>
+          <String>SubSysToArbiter</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_bVeto</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Arbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_stCurrentBP</Name>
+        <Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcLinkTo</Name>
+            <Value>TIIB[PMPS_PRE]^IO Inputs^CurrentBP</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_stRequestedBP</Name>
+        <Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>2560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcLinkTo</Name>
+            <Value>TIIB[PMPS_PRE]^IO Outputs^RequestedBP</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xTxPDO_toggle</Name>
+        <Type>BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>4320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: TxPDO_toggle
+        io: i</Value>
+          </Property>
+          <Property>
+            <Name>TcLinkTo</Name>
+            <Value>TIIB[PMPS_PRE]^SYNC Inputs^TxPDO toggle</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xTxPDO_state</Name>
+        <Type>BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>4321</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: TxPDO_state
+        io: i</Value>
+          </Property>
+          <Property>
+            <Name>TcLinkTo</Name>
+            <Value>TIIB[PMPS_PRE]^SYNC Inputs^TxPDO state</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffPMPSIO_Disconnect</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Fast faults</Comment>
+        <BitSize>25088</BitSize>
+        <BitOffs>4352</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Arbiter network interface disconnected or not OP</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_DevName</Name>
+            <String>SubSysToArbiter</String>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nRequestCohort</Name>
+        <Type>UDINT</Type>
+        <Comment> Request cohort</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>29440</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: RequestCohort
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveCohort</Name>
+        <Type>UDINT</Type>
+        <Comment> Active cohort, updated by incoming BP from arbiter PLC, in the ElevateRequest arbiter call</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>29472</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: ActiveCohort
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbVetoArb</Name>
+        <Type Namespace="PMPS">FB_VetoArbiter</Type>
+        <BitSize>27168</BitSize>
+        <BitOffs>29504</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLog</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>81984</BitSize>
+        <BitOffs>56704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__CHECKREQUEST__XFIRSTTIME</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>138688</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>__CHECKREQUEST__NID</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>138720</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>xFirstTime</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__CHECKREQUEST__XFIRSTTIME</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nId</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__CHECKREQUEST__NID</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>RequestBP</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID of state requesting beam parameter set</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>stReqBP</Name>
+          <Comment>Requested beam params</Comment>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Comment>StateID to remove</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_GaugeBase</Name>
+      <BitSize>85312</BitSize>
+      <SubItem>
+        <Name>fbLogger</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <Comment>Logging </Comment>
+        <BitSize>81984</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.eSubsystem</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ePrevState</Name>
+        <Type Namespace="LCLS_Vacuum">E_PressureState</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>82048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tErrorPresent</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tAction</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment> Primary action of this device (OPN_DO, etc.)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>82144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOverrideActivated</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tState</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>82336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRestorePersistentData</Name>
+        <Type>BOOL</Type>
+        <Comment> For Persistent Data</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>82984</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stateTimer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>83008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIdx</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>83232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbWritePersistentData</Name>
+        <Type Namespace="Tc2_Utilities">WritePersistentData</Type>
+        <BitSize>1600</BitSize>
+        <BitOffs>83360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tRecover</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>84960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rVAC_SP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>85184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rPRO_SP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>85216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rHYS_PR</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>85248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_MKS317</Name>
+      <Comment> This function is for the Pirani MKS 317 connected to a 937A/B 
+ This function block is used to provide protection and automatic turn on of ion gauges,
+ it also manages the turn on of the AT_VAC boolean, and checks to make sure the pressure is good </Comment>
+      <BitSize>86720</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
+      <SubItem>
+        <Name>b937A</Name>
+        <Type>BOOL</Type>
+        <Comment> True if this gauge is connected to MKS937A controller, False if connected to MKS937B controller</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>85312</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>85344</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: 
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS_R</Name>
+        <Type>INT</Type>
+        <Comment> input Pressure // Link to analog Input</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>86432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rMinPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86464</BitOffs>
+        <Default>
+          <Value>0.0001</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDefaultVAC_SP</Name>
+        <Type>REAL</Type>
+        <Comment> Default 50 mT</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86496</BitOffs>
+        <Default>
+          <Value>0.05</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDisconnectedBoundary</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86528</BitOffs>
+        <Default>
+          <Value>0.1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidLoBoundary</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86560</BitOffs>
+        <Default>
+          <Value>0.22</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidBoundaryMin</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86592</BitOffs>
+        <Default>
+          <Value>0.6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidHiBoundary</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86624</BitOffs>
+        <Default>
+          <Value>9.7</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidHiBoundaryMax</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86656</BitOffs>
+        <Default>
+          <Value>9.9</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rNoSensorBoundary</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86688</BitOffs>
+        <Default>
+          <Value>10</Value>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_MKS275</Name>
+      <Comment> This function block is used to provide protection and automatic turn on of ion gauges,
+ it also manages the turn on of the AT_VAC boolean, and checks to make sure the pressure is good 
+ For MKS 275 mini-convectron </Comment>
+      <BitSize>86720</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
+      <SubItem>
+        <Name>PG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>85312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: 
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>V</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iTermBits</Name>
+        <Type>UINT</Type>
+        <Comment> The terminal's maximum value in bits</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>86400</BitOffs>
+        <Default>
+          <Value>32767</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Vlowest</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86432</BitOffs>
+        <Default>
+          <Value>10</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS_R</Name>
+        <Type>INT</Type>
+        <Comment> input Pressure // Link to analog Input</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>86464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MinPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86496</BitOffs>
+        <Default>
+          <Value>0.0001</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDeadband</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86528</BitOffs>
+        <Default>
+          <Value>0.05</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidLoBoundary</Name>
+        <Type>REAL</Type>
+        <Comment>  0.375V as per manual page 27</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86560</BitOffs>
+        <Default>
+          <Value>0.375</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rValidHiBoundary</Name>
+        <Type>REAL</Type>
+        <Comment> 5.534; // manual page 27</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86592</BitOffs>
+        <Default>
+          <Value>5.659</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDisconnectedBoundary</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86624</BitOffs>
+        <Default>
+          <Value>0.3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDefaultVAC_SP</Name>
+        <Type>REAL</Type>
+        <Comment>Default set point 50 mT</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86656</BitOffs>
+        <Default>
+          <Value>0.05</Value>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Method>
+        <Name>M_SetBits</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TermBits</Name>
+          <Comment> The terminal's maximum value in bits</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_check</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_MKS422</Name>
+      <Comment> This function is for the Cold Cathode MKS 422 connected to a 937A/B 
+This function provides ILK and Set Point Protection for the Cold Cathode</Comment>
+      <BitSize>88064</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
+      <SubItem>
+        <Name>PG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment> Pirani Gauge Structure used to Interlock the Cold Cathode</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>85312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>b937A</Name>
+        <Type>BOOL</Type>
+        <Comment> True if this gauge is connected to MKS937A controller, False if connected to MKS937B controller</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>86368</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tRecoverDelay</Name>
+        <Type>TIME</Type>
+        <Comment>Delay Time after the first cycle to start the device. Default is 600S</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86400</BitOffs>
+        <Default>
+          <Value>600000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>IG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment> The Cold Cathode Data Structure</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>86432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: 
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>87520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS_R</Name>
+        <Type>INT</Type>
+        <Comment> Controls and I/Os</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>87744</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xHV_DIS</Name>
+        <Type>BOOL</Type>
+        <Comment> Disable Gauge High Voltage when True // 'TcLinkTo' (EL2794) ^Output</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>87760</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MinPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87776</BitOffs>
+        <Default>
+          <Value>1E-11</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vDisconnected</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87808</BitOffs>
+        <Default>
+          <Value>0.18</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vMaxValid</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87840</BitOffs>
+        <Default>
+          <Value>9.6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vMax</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87872</BitOffs>
+        <Default>
+          <Value>9.9</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vValidLo</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87904</BitOffs>
+        <Default>
+          <Value>0.22</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vMin</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87936</BitOffs>
+        <Default>
+          <Value>0.6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cDefaultPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87968</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bWasOn</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88000</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecover</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecoverWrite</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88016</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Recover</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Method>
+        <Name>M_HVE</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>enable</Name>
+          <Comment> set to true to enable, false to disable;</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>M_Recover</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>M_AutoOn</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_MKS500</Name>
+      <Comment> This function is for the Cold Cathode MKS 500. If connected to Beckhoff EP boxes.
+Set the EP bit to TRUE, this is necessary for the MKS500-to-EP box interface beacuse the EP
+boxes do not natively support the 5v IO signals on the MKS500 gauge.
+This function provides ILK and Set Point Protection for the Cold Cathode</Comment>
+      <BitSize>88384</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
+      <SubItem>
+        <Name>PG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>85312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEP</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to True if This Gauge is connected to EP BOX and not EL Terminals</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>86368</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tRecoverDelay</Name>
+        <Type>TIME</Type>
+        <Comment>Delay Time after the first cycle to start the device. Default is 600S</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86400</BitOffs>
+        <Default>
+          <Value>600000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>IG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>86432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: 
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>GaugeTurnOnTmr</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>87520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tStartupTimer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>87744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iTermBits</Name>
+        <Type>UINT</Type>
+        <Comment> The terminal's maximum value in bits</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>87968</BitOffs>
+        <Default>
+          <Value>32767</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS_R</Name>
+        <Type>INT</Type>
+        <Comment> Controls and I/Os</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>87984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xHV_DIS</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable High Voltage when True // 'TcLinkTo' (EP2624) ^Output</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88000</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xHV_ON</Name>
+        <Type>BOOL</Type>
+        <Comment>  True when High Voltage is on  // 'TcLinkTo' (EL1124) ^Input</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xDisc_Active</Name>
+        <Type>BOOL</Type>
+        <Comment> Discharge Current Active // 'TcLinkTo' (EL1124) ^Input</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88016</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>binit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88024</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>pBase</Name>
+        <Type>REAL</Type>
+        <Comment>default curve base pressure is 1E-10. Confusing since can't actually read that low using analog out.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>88032</BitOffs>
+        <Default>
+          <Value>1E-10</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vBase</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88064</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vDisconnected</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88096</BitOffs>
+        <Default>
+          <Value>0.5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vSlope</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88128</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vGaugeOff</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88160</BitOffs>
+        <Default>
+          <Value>9.8</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>vNoDischarge</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88192</BitOffs>
+        <Default>
+          <Value>9.3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>MinPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88224</BitOffs>
+        <Default>
+          <Value>1E-10</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cDefaultPressure</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDeadband</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88288</BitOffs>
+        <Default>
+          <Value>0.3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bWasOn</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecover</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecoverWrite</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Recover</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Method>
+        <Name>M_HVE</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>enable</Name>
+          <Comment> set to true to enable, false to disable;</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>M_SetBits</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TermBits</Name>
+          <Comment> The terminal's maximum value in bits</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>M_Recover</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">ST_ValveBase</Name>
+      <BitSize>800</BitSize>
+      <SubItem>
+        <Name>pv_xOPN_SW</Name>
+        <Type>BOOL</Type>
+        <Comment> EPICS Controls </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: OPN_SW; 
+	field: ZNAM CLOSE; 
+	field: ONAM OPEN;
+	io: io ;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pv_xAlmRst</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ALM_RST;
+	io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pv_xOvrdOpn</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: FORCE_OPN;
+	io: io;
+	field: ZNAM FALSE;
+	field: ONAM FORCE OPEN;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment> Shows the override status of this valve </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: OVRD_ON ;
+	field: ZNAM Override OFF ;
+	field: ONAM Override ON;
+	io: io;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xOpnLS</Name>
+        <Type>BOOL</Type>
+        <Comment> I/Os
+ Readbacks </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: OPN_DI;
+	io: i;
+	field: ZNAM FALSE;
+	field: ONAM OPEN;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xClsLS</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>40</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: CLS_DI;
+	io: i;
+	field: ZNAM FALSE;
+	field: ONAM CLOSE;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xOPN_DO</Name>
+        <Type>BOOL</Type>
+        <Comment> Controls </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>48</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: OPN_DO;
+	io: i;
+	field: ZNAM FALSE;
+	field: ONAM TRUE;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xEXT_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> External interlock for custom interlocking in addition to regular DP ilk, this must be set true, or the interlock condition before calling the FB_VGC </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>56</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: EXT_ILK_OK ;
+	field: ZNAM NOT OK ;
+	field: ONAM OK ;
+	io: i ;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOPN_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Final SUM of DP_OK and EXT_OK, needed because it allows the DP ilk to be switched off, see FB_VGC.Dis_DPIlk </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: OPN_OK;
+	field: ZNAM OPN ILK NOT OK ;
+	field: ONAM OPN ILK OK ;
+	io: i;
+ 	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="LCLS_Vacuum">E_ValvePositionState</Type>
+        <Comment> States </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: POS_STATE;
+	type: mbbi ;
+	field: ZRST OPEN ;
+	field: ONST CLOSED ;
+	field: TWST MOVING ;
+	field: THST INVALID ;
+	field: FRST OPEN_F ;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eVGC_State</Name>
+        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: STATE;
+	field: ZRST Vented;
+	field: ONST At Vacuum;
+	field: TWST Differential Pressure;
+	field: THST Lost Vacuum;
+	field: FRST Ext Fault;
+	field: FVST AT Vacuum;
+	field: SXST Triggered;
+	field: SVST Vacuum Fault;
+	field: EIST Close Timeout;
+	field: NIST Open Timeout;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bErrorPresent</Name>
+        <Type>BOOL</Type>
+        <Comment> Error </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERROR;
+	field: ZNAM NO ERROR ;
+	field: ONAM ERROR PRESENT ;
+	io: o;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iErrorCode</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ErrMsg;
+	io: o;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xLog</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>792</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: LOGGER;
+	io: io;
+	field: ZNAM OFF ;
+	field: ONAM ON ;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">ST_VGC</Name>
+      <BitSize>2944</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">ST_ValveBase</ExtendsType>
+      <SubItem>
+        <Name>xDP_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Indicates the valve can be opened because the differential pressure is low enough</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: DP_OK;
+	field: ZNAM DP NOT OK ;
+	field: ONAM DP OK ;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rAT_VAC_SP</Name>
+        <Type>REAL</Type>
+        <Comment> Interlock setpoint for gauges on both sides of valve</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>832</BitOffs>
+        <Default>
+          <Value>1E-06</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: AT_VAC_SP;
+	io: o;
+	field: HOPR 1000
+	field: LOPR 0
+	field: PREC 2
+	field: EGU "TORR"
+	autosave_pass1: VAL DESC
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rAT_VAC_SP_LAST</Name>
+        <Type>REAL</Type>
+        <Comment> Interlock setpoint for gauges on both sides of valve</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>864</BitOffs>
+        <Default>
+          <Value>1E-06</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rAT_VAC_HYS</Name>
+        <Type>REAL</Type>
+        <Comment> Hysteresis of the vacuum sp</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Default>
+          <Value>1E-06</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: AT_VAC_HYS;
+	io: o;
+	field: HOPR 1000
+	field: LOPR 0
+	field: PREC 2
+	field: EGU "TORR"
+	autosave_pass1: VAL DESC
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rHYST_PERC</Name>
+        <Type>REAL</Type>
+        <Comment> Hysteresis percentage</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>928</BitOffs>
+        <Default>
+          <Value>0.8</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: HYST_PERC ;
+	io: o;
+	autosave_pass1: VAL DESC
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xAT_VAC</Name>
+        <Type>BOOL</Type>
+        <Comment>At vacuum setpoint</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: AT_VAC ; 
+	field: ZNAM NOT AT VAC ;
+	field: ONAM AT VAC ;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xERR_DifPres</Name>
+        <Type>BOOL</Type>
+        <Comment> Alarm Outputs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>968</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERR_DifPres;
+	field: ZNAM NO ERROR ;
+	field: ONAM Diffrential error present ;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xERR_SP</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERR_SP;
+	field: ZNAM NO ERROR ;
+	field: ONAM Setpoint error present ;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xERR_ExtFault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERR_Ext;
+	field: ZNAM NO ERROR ;
+	field: ONAM External error present ;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xAlmSum</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sDevName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1000</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sIlkUSDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment>ILK Devices</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_DEVICE_US;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sIlkDSDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>2296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_DEVICE_DS;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">E_BPTMState</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>Init</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NewTarget</Text>
+        <Enum>1000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>RequestBP</Text>
+        <Enum>1500</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WaitForBP</Text>
+        <Enum>2500</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WaitingForTransitionAssertion</Text>
+        <Enum>2000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WaitingForFinalAssertion</Text>
+        <Enum>3000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Transitioning</Text>
+        <Enum>4000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WaitForFinalBP</Text>
+        <Enum>5000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CleaningUp</Text>
+        <Enum>6000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Idle</Text>
+        <Enum>10000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Done</Text>
+        <Enum>8000</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Error</Text>
+        <Enum>9000</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_Index</Name>
+      <Comment> Index FB
+A. Wallace 2016-9-3
+
+Why doesn't beckhoff have this as a builtin type?
+
+Use this thing to have a simple indexer with rollover.
+
+</Comment>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>LowerLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ValInc</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer increments by this value</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>UpperLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollover at this value to lower limit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nVal</Name>
+        <Type>INT</Type>
+        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>Dec</Name>
+      </Action>
+      <Action>
+        <Name>Inc</Name>
+      </Action>
+      <Method>
+        <Name>DecVal</Name>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IncVal</Name>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">BeamParameterTransitionManager</Name>
+      <Comment>
+Implements the procedure for safely transitioning between device states.
+
+NOTE:
+The BPTM will throw an error if the arbiter does not have enough space for the transition and new final assertion. 
+
+ </Comment>
+      <BitSize>60256</BitSize>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment>Connect to local arbiter</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Name of the device requesting the transition	</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <String>Device</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_TransitionAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> Must not be 0 or EXCLUDED_ID</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>736</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_stTransitionAssertion</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment>Assertion required during transition (always safer than anything inbetween)</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_nRequestedAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> Must not be 0 or EXCLUDED_ID</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2528</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_stRequestedAssertion</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> PMPS_GVL.cstSafeBeam; //Requested assertion, change whenever</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>2560</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.nTran</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.neVRange</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nRate</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nBCRange</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xMoving</Name>
+        <Type>BOOL</Type>
+        <Comment>Provide rising edge when device begins moving &lt;remove&gt;</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4320</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xDoneMoving</Name>
+        <Type>BOOL</Type>
+        <Comment>Provide rising edge when device is done with a move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4328</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentBeamParameters</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment>Connect to current beam parameters</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>4352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRetry</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge to cycle back through the BPTM process. Use if something in the process timed out or failed. This will interrupt a current process</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6112</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment>Rising edge indicating the device is safe to move, use as input to move execute (which requires a rising edge)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6120</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set if some issue occurs within the bptm</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UINT</Type>
+        <Comment> Set to non-zero to help understand the error.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>6144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTargetAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>6176</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stTargetAssertion</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Target assertion</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>6208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrentAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> ID of last set state (zero until a state is reached)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>7968</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xNewBP</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8000</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xTranBP</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFinalBPInArb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFinalBP</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eBPTMState</Name>
+        <Type Namespace="PMPS">E_BPTMState</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>8032</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ePrevState</Name>
+        <Type Namespace="PMPS">E_BPTMState</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>8048</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xEntry</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rTransition</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xNewTarget</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bTransAssertionFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFinalAssertionFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LogStrBuffer</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>41</Elements>
+        </ArrayInfo>
+        <BitSize>26568</BitSize>
+        <BitOffs>8184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LogBuffIdx</Name>
+        <Type Namespace="LCLS_General">FB_Index</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>34752</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.LowerLimit</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.UpperLimit</Name>
+            <Value>40</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nAssrtAttempt</Name>
+        <Type>INT</Type>
+        <Comment> Number of times we have tried asserting a BP set</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>34848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtRetry</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>34880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtError</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>34944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffTimeout</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>35008</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Preemptive requests timed out in BPTM</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>10</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_xAutoReset</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rtDoneMoving</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>60096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLatchDoneMoving</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>60160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>60168</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>LogBuffSize</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>60176</BitOffs>
+        <Default>
+          <Value>40</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cMaxAttempts</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>60192</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cReqArbCapacity</Name>
+        <Type>UDINT</Type>
+        <Comment> The thought here is, a BPTM needs at most 2 arbiter slots to complete a transition.
+    If we're at capacity, it means some BPTM before this one has begun a transition,
+    and will require at least one more arbiter spot to complete. 
+    </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>60224</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>AuthorizeTransition</Name>
+      </Action>
+      <Action>
+        <Name>WaitingForFinalAssertion_DO</Name>
+      </Action>
+      <Action>
+        <Name>NewTarget_ENTRY</Name>
+      </Action>
+      <Action>
+        <Name>AssertTransitionBP</Name>
+      </Action>
+      <Action>
+        <Name>AssertFinalBP</Name>
+      </Action>
+      <Action>
+        <Name>WaitingForTransitionAssertion_DO</Name>
+      </Action>
+      <Action>
+        <Name>RemoveTransitionAssertion</Name>
+      </Action>
+      <Action>
+        <Name>SetNewTarget</Name>
+      </Action>
+      <Action>
+        <Name>RequestBP_DO</Name>
+      </Action>
+      <Action>
+        <Name>WaitingForTransitionAssertion_EXIT</Name>
+      </Action>
+      <Action>
+        <Name>WaitingForFinalAssertion_EXIT</Name>
+      </Action>
+      <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Method>
+        <Name>LogActions</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>LogStr</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_check</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_VGC</Name>
+      <Comment> This function block implements basic functionality for Isolation Gate Valves
+ This function block interlock is as follows:
+1. The valve can be opened when the difference between the pressures on both sides is
+less than the maximum differential pressure.
+2. This rule persists until the pressures on both sides are lower than the vacuum-setpoint.
+3. Once at-vac, the valve will close if the pressure on either side rises above the setpoint.
+This function block also implements PMPS and EPS interlocks, as well as Fast MPS trigger</Comment>
+      <BitSize>177344</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_Valve</ExtendsType>
+      <SubItem>
+        <Name>i_stUSG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment>Upstream Gauge, usually ion gauge</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>82304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_stDSG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment>Downstream Gauge, usually ion gauge</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>83360</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xDis_DPIlk</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to true when calling the function to disable the differential pressure interlock </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84416</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: Dis_DPIlk
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xPMPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>Set to True To switch off the bptm and PMPS Arbiter</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xEPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>External EPS interlock, Set to TRUE when no EPS interlock is required, otherwise set to correct interlock signal</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84432</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: EPS_OK
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xExt_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>Other External Interlock, Set to True when no external interlock is required. If this Valve is neigboring a Fast Shutter this should be linked to the fast shutter xVAC_FAULT_OK</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>To be linked to global override bit. This Overrides Vacuum logic only, EPS, MPS and PMPS are still enforces</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset fault</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: FF_Reset
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xIsAperture</Name>
+        <Type>BOOL</Type>
+        <Comment> Set tp True if this is an Aperture Valve, the MPS Fault will trip only when moving.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>84464</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_sDevName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Device name for diagnostic</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>84472</BitOffs>
+        <Default>
+          <String>VGC</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_nTransitionRootID</Name>
+        <Type>UDINT</Type>
+        <Comment>A unique transition Root ID that is equal to or greater than 1000</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>86528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iq_stValve</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
+        <Comment> All valve data and states will be in this struct</Comment>
+        <BitSize>2944</BitSize>
+        <BitOffs>86560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv:
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xMPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>MPS Fast OK, is set when the Valve is Open</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: MPS_FAULT_OK
+	field: ZNAM MPS FAULT ;
+	field: ONAM MPS OK ;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>89536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>89568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xPMPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>PMPS interlock</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89600</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: MPS_OK
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoving</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tBPTMtimeout</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>89632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bptm</Name>
+        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
+        <BitSize>60256</BitSize>
+        <BitOffs>89856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FFO</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>150112</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Fault occurs when the valve is not in open state</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>4112</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type>STRING(80)</Type>
+        <Comment>g_FastFaultOutput1	:	FB_HardwareFFOutput;	</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>175200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rDiffPressAllowed</Name>
+        <Type>REAL</Type>
+        <Comment> Torr, Default value comes from Vat Valve Manual</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>175872</BitOffs>
+        <Default>
+          <Value>22.5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rDiffPress</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>175904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>set</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>175936</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>reset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>175944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstPass</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>175952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFSInit</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>175968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonDelOK</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>176032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtOK</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>176256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonOvrd</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>176320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtOpen</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>176544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftClose</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>176608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tDelOK</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>176672</BitOffs>
+        <Default>
+          <Value>60000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tOvrd</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>176704</BitOffs>
+        <Default>
+          <Value>10000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeOutDuration</Name>
+        <Type>TIME</Type>
+        <Comment> Timeouts</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>176736</BitOffs>
+        <Default>
+          <Value>30000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tOPNtimeout</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>176768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tCLStimeout</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>176992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>i_xOpnLS</Name>
+        <Type>BOOL</Type>
+        <Comment>IO</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>177216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xClsLS</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>177224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xOPN_DO</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>177232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eVGCPrevState</Name>
+        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
+        <Comment> For logging</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>177248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rAT_VAC_SP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>177280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rHYST_PERC</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>177312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>ACT_IO</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Action>
+        <Name>ACT_ResetAlarms</Name>
+      </Action>
+      <Action>
+        <Name>ACT_PMPS</Name>
+      </Action>
+      <Method>
+        <Name>M_IsClosed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>M_IsOpen</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>M_Set_OPN_SW</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_check</Name>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">ST_VFS</Name>
+      <BitSize>2128</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">ST_ValveBase</ExtendsType>
+      <SubItem>
+        <Name>i_xTrigger</Name>
+        <Type>BOOL</Type>
+        <Comment> Interlock </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: TRIG; 
+	field: ZNAM TRIG_OFF; 
+	field: ONAM TRIG_ON;
+	io: i ;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xCLS_SW</Name>
+        <Type>BOOL</Type>
+        <Comment>external open signal e.g epics</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>808</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: CLS_SW; 
+	field: ZNAM FALSE; 
+	field: ONAM CLOSE;
+	io: io ;
+	</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xERR_ExtFault</Name>
+        <Type>BOOL</Type>
+        <Comment> Alarm Outputs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>816</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERR_Ext;
+	field: ZNAM NO ERROR ;
+	field: ONAM External error present ;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVAC_FAULT_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: VAC_FAULT_OK; 
+	field: ZNAM FAULT ; 
+	field: ONAM FAULT OK;
+	io: i ;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sGFS</Name>
+        <Type>STRING(80)</Type>
+        <Comment>ILK Devices</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: GFS;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sVetoDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: VETO_DEVICE;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_VFS_Interface</Name>
+      <Comment>Used as soft IO mapping to create a psuedo valve to communicate over two task on the same PLC.
+for FAST shutter control</Comment>
+      <BitSize>89344</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_Valve</ExtendsType>
+      <SubItem>
+        <Name>IG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment> The MKS422 Cold Cathode Data Structure</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>82304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Veto_Valve</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
+        <Comment> The VGC structure for the Veto Valve</Comment>
+        <BitSize>2944</BitSize>
+        <BitOffs>83360</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iq_stValve</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VFS</Type>
+        <Comment> All valve data and states will be in this struct</Comment>
+        <BitSize>2128</BitSize>
+        <BitOffs>86304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVAC_FAULT_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtTriggerVetoed</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>88448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTriggered</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>88512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonOvrd</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>88576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOvrd</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>88800</BitOffs>
+        <Default>
+          <Value>10000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rtOK</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>88832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonDelOK</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>88896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xOPN_OK</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tDelOK</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>89152</BitOffs>
+        <Default>
+          <Value>60000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>q_xPRESS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>outputs</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xOPN_SW</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xCLS_SW</Name>
+        <Type>BOOL</Type>
+        <Comment>external open signal e.g epics</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xVAC_FAULT_Reset</Name>
+        <Type>BOOL</Type>
+        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>To be linked to global override bit. This Overrides Vacuum logic only, EPS, MPS and PMPS are still enforces</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xOverrideOpen</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xVetoValveOpenDO</Name>
+        <Type>BOOL</Type>
+        <Comment>VETO Devices</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xVetoValveClosed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xTrigger</Name>
+        <Type>BOOL</Type>
+        <Comment>inputs</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVFS_Open</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVFS_Closed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>89264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xMPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment>MPS Fault OK, is set when the Valve is Open and there is no trigger</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>89272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: MPS_FAULT_OK
+	field: ZNAM MPS FAULT ;
+	field: ONAM MPS OK ;
+	io: i ;
+	</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_eVFS_State</Name>
+        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
+        <Comment>Interface</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>89280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">E_PumpState</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>pumpSTOPPED</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>pumpSTARTING</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>pumpRUNNING</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>pumpFAULT</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>pumpSTOPPING</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_Pump</Name>
+      <BitSize>82624</BitSize>
+      <SubItem>
+        <Name>fbLogger</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <Comment> For logging</Comment>
+        <BitSize>81984</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.eSubsystem</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ePrevState</Name>
+        <Type Namespace="LCLS_Vacuum">E_PumpState</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>82048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tErrorPresent</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tAction</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment> Primary action of this device (OPN_DO, PUMP_RUN, etc.)	</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>82144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tFault</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tILK</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>82272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bRestorePersistentData</Name>
+        <Type>BOOL</Type>
+        <Comment> For Persistent Data</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>82496</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rBackingPressureSP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>82528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rInletPressureSP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>82560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">ST_PIP</Name>
+      <BitSize>1600</BitSize>
+      <SubItem>
+        <Name>xILKOk</Name>
+        <Type>BOOL</Type>
+        <Comment> Read back 
+ 	i_xHVisON : BOOL; 
+ Interlock </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_OK;
+	field: ZNAM NOT OK ;
+	field: ONAM OK ;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ERROR;
+	field: ZNAM FALSE ;
+	field: ONAM TRUE ;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rHVEna_SP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0.0001</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: AT_VAC_SP;
+	io: io;
+	field: HOPR 1000
+	field: LOPR 0
+	field: PREC 2
+	field: EGU "TORR"
+	autosave_pass1: VAL DESC
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sIlkDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_DEVICE;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type>STRING(80)</Type>
+        <Comment>Required for other devices using this gauge as interlock</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xHVEna_SW</Name>
+        <Type>BOOL</Type>
+        <Comment> EPICS Controls </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1360</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: HV_SW;
+	io: io;
+	field: ZNAM OFF; 
+	field: ONAM ON;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xAutoOn</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1368</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: Auto_On;
+	field: ZNAM FALSE; 
+	field: ONAM TRUE;
+	io:io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iAutoOnTimer</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1376</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: AutoOn_timer;
+	io:i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment> Shows the override status of this valve </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: OVRD_ON ;
+	field: ZNAM Override OFF ;
+	field: ONAM Override ON;
+	io: io;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pv_xOvrdStart</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: FORCE_START;
+	io: io;
+	field: ZNAM FALSE;
+	field: ONAM FORCE START;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rHYS_PR</Name>
+        <Type>REAL</Type>
+        <Comment> Protection setpoint hysteresis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1408</BitOffs>
+        <Default>
+          <Value>0.001</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: SP_HYS;
+	io: io;
+	field: HOPR 1000
+	field: LOPR 0
+	field: PREC 2
+	field: EGU "TORR"
+	autosave_pass1: VAL DESC
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iOffset</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1440</BitOffs>
+        <Default>
+          <Value>13</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: AI_Offset;
+	io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOutputInverted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: Inverted;
+	field: ZNAM NORMAL; 
+	field: ONAM INVERTED;
+	io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xHVEna_DO</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable High Voltage when True // 'TcLinkTo' (EL1124) ^Input</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: HV_DO;
+	field: ZNAM OFF; 
+	field: ONAM ON;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rPRESS</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: PRESS;
+	field: HOPR 1000
+	field: LOPR 0
+	field: PREC 2
+	field: EGU "TORR"
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: PRESS_AI;
+	io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xHV_DI</Name>
+        <Type>BOOL</Type>
+        <Comment> NO contact // 'TcLinkTo' (EL1004) ^Input</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: HV_DI;
+	field: ZNAM FALSE; 
+	field: ONAM TRUE;
+	io:i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="LCLS_Vacuum">E_PumpState</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1552</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+	pv: STATE;
+	field: ZRST STOPPED;
+	field: ONST STARTING;
+	field: TWST RUNNING;
+	field: THST FAULT;
+	field: FRST STOPPING;
+	io: i;
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xLog</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1568</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: LOGGER;
+	io: io;
+	field: ZNAM OFF ;
+	field: ONAM ON ;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_Vacuum">FB_PIP_Gamma</Name>
+      <Comment> This function block does basic controls FOR the ION pump connected to a Gamma QPCe controller.
+ Provides interlocking interface. Enable HV only when interlock gauge press is less than 1.0E-4 Torr </Comment>
+      <BitSize>90624</BitSize>
+      <ExtendsType Namespace="LCLS_Vacuum">FB_Pump</ExtendsType>
+      <SubItem>
+        <Name>i_stGauge</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment>Ion or Pirani gauge for pump interlock</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>82624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>To be linked to global override bit. This Overrides Vacuum interlock logic</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>83680</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tRecoverDelay</Name>
+        <Type>TIME</Type>
+        <Comment>Delay Time after the first cycle to start the device. Default is 900S</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>83712</BitOffs>
+        <Default>
+          <Value>900000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPump</Name>
+        <Type Namespace="LCLS_Vacuum">ST_PIP</Type>
+        <Comment>Gamma Ion pump structure</Comment>
+        <BitSize>1600</BitSize>
+        <BitOffs>83744</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: 
+	</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_IG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <Comment>When ion pump is used as a measuring device for interlocking gate valves</Comment>
+        <BitSize>1056</BitSize>
+        <BitOffs>85344</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rPRESS</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>86432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>86464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>q_xHVEna_DO</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable High Voltage when TRUE</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>86688</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_iPRESS</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>86704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xSP_DI</Name>
+        <Type>BOOL</Type>
+        <Comment> NO contact //function of relay set on the QPC to HV output state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>86720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeOutAction</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <Comment> For logging</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>86752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOverrideActivated</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>86816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tPumpStartTimeout</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Timeout pump start if pressure &lt; 1E-11 for more than 10s.</Comment>
+        <BitSize>224</BitSize>
+        <BitOffs>86880</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <Value>10000</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>MinPressure</Name>
+        <Type>REAL</Type>
+        <Comment> Minimum readback pressure, pump must register pressure above this to be considered running</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>87104</BitOffs>
+        <Default>
+          <Value>1E-11</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stateTimer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>87136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonOvrd</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment>Overrides</Comment>
+        <BitSize>224</BitSize>
+        <BitOffs>87360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonDelOK</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>87584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtOK</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>87808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOvrd</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>87872</BitOffs>
+        <Default>
+          <Value>10000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>87904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIdx</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>88576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbWritePersistentData</Name>
+        <Type Namespace="Tc2_Utilities">WritePersistentData</Type>
+        <BitSize>1600</BitSize>
+        <BitOffs>88704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tRecover</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>90304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rDefaultHVEna_SP</Name>
+        <Type>REAL</Type>
+        <Comment> Default protection setpoint as per the gamma QPCe manual</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>90528</BitOffs>
+        <Default>
+          <Value>0.0001</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rHVEna_SP</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>90560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bWasOn</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>90592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecover</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>90600</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoRecoverWrite</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>90608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Action>
+        <Name>ACT_IlkOverride</Name>
+      </Action>
+      <Action>
+        <Name>ACT_SetGauge</Name>
+      </Action>
+      <Action>
+        <Name>IO</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Recover</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Persistent</Name>
+      </Action>
+      <Method>
+        <Name>M_Run</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>run</Name>
+          <Comment> set to true to run, false to stop;</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>M_Recover</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>M_AutoOn</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>ST_EXT_GCC</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>xIlk_Inp</Name>
+        <Type>BOOL</Type>
+        <Comment> Report the input signal .</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ILK_INP;
+        io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name>FB_EXT_TREATY_GAUGE</Name>
+      <BitSize>1184</BitSize>
+      <SubItem>
+        <Name>rTREATY_SIGNAL_PRESS</Name>
+        <Type>REAL</Type>
+        <Comment>	Setpoint agreed upon w/ the external system signified by the signal they send.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rNO_SIGNAL_PRESS</Name>
+        <Type>REAL</Type>
+        <Comment> Presumed pressure if the signal is not received.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>IG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv:
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>EXT_IG</Name>
+        <Type>ST_EXT_GCC</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv:
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xEXT_Press_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Input from AD's system indicating pressure belopw setpoint.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_EXT_TREATY_VGC</Name>
+      <BitSize>3008</BitSize>
+      <SubItem>
+        <Name>TREATY_VGC</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
+        <BitSize>2944</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xTREATY_VGC_STATUS</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>ST_EXT_ILK</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>xIlk_sw</Name>
+        <Type>BOOL</Type>
+        <Comment> EPICS control for switching the interlock on or off.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: HV_SW;
+    io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xILK_OK_DO</Name>
+        <Type>BOOL</Type>
+        <Comment> Readout of the external interlock's ouput value</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_DO;
+    io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xIlkOK</Name>
+        <Type>BOOL</Type>
+        <Comment> Interlock Bit</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: ILK_OK;
+    io: i;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rPRO_SP</Name>
+        <Type>REAL</Type>
+        <Comment> Pressure below which the HV signal may turn on</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>1E-06</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+    pv: PRO_SP;
+    io: io;
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name>FB_EXT_ILK</Name>
+      <BitSize>1152</BitSize>
+      <SubItem>
+        <Name>VG</Name>
+        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
+        <BitSize>1056</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ILK</Name>
+        <Type ReferenceTo="true">ST_EXT_ILK</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xILK_OK_DO</Name>
+        <Type>BOOL</Type>
+        <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_Vacuum">FB_ADS</Name>
       <BitSize>82112</BitSize>
       <SubItem>
@@ -20107,652 +26619,6 @@ These features aren't disabled, they just aren't used, think child/parent classe
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_Vacuum">ST_ValveBase</Name>
-      <BitSize>800</BitSize>
-      <SubItem>
-        <Name>pv_xOPN_SW</Name>
-        <Type>BOOL</Type>
-        <Comment> EPICS Controls </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: OPN_SW; 
-	field: ZNAM CLOSE; 
-	field: ONAM OPEN;
-	io: io ;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pv_xAlmRst</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ALM_RST;
-	io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pv_xOvrdOpn</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: FORCE_OPN;
-	io: io;
-	field: ZNAM FALSE;
-	field: ONAM FORCE OPEN;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment> Shows the override status of this valve </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: OVRD_ON ;
-	field: ZNAM Override OFF ;
-	field: ONAM Override ON;
-	io: io;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xOpnLS</Name>
-        <Type>BOOL</Type>
-        <Comment> I/Os
- Readbacks </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: OPN_DI;
-	io: i;
-	field: ZNAM FALSE;
-	field: ONAM OPEN;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xClsLS</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>40</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: CLS_DI;
-	io: i;
-	field: ZNAM FALSE;
-	field: ONAM CLOSE;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xOPN_DO</Name>
-        <Type>BOOL</Type>
-        <Comment> Controls </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>48</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: OPN_DO;
-	io: i;
-	field: ZNAM FALSE;
-	field: ONAM TRUE;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xEXT_OK</Name>
-        <Type>BOOL</Type>
-        <Comment> External interlock for custom interlocking in addition to regular DP ilk, this must be set true, or the interlock condition before calling the FB_VGC </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>56</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: EXT_ILK_OK ;
-	field: ZNAM NOT OK ;
-	field: ONAM OK ;
-	io: i ;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xOPN_OK</Name>
-        <Type>BOOL</Type>
-        <Comment> Final SUM of DP_OK and EXT_OK, needed because it allows the DP ilk to be switched off, see FB_VGC.Dis_DPIlk </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: OPN_OK;
-	field: ZNAM OPN ILK NOT OK ;
-	field: ONAM OPN ILK OK ;
-	io: i;
- 	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="LCLS_Vacuum">E_ValvePositionState</Type>
-        <Comment> States </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: POS_STATE;
-	type: mbbi ;
-	field: ZRST OPEN ;
-	field: ONST CLOSED ;
-	field: TWST MOVING ;
-	field: THST INVALID ;
-	field: FRST OPEN_F ;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eVGC_State</Name>
-        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: STATE;
-	field: ZRST Vented;
-	field: ONST At Vacuum;
-	field: TWST Differential Pressure;
-	field: THST Lost Vacuum;
-	field: FRST Ext Fault;
-	field: FVST AT Vacuum;
-	field: SXST Triggered;
-	field: SVST Vacuum Fault;
-	field: EIST Close Timeout;
-	field: NIST Open Timeout;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bErrorPresent</Name>
-        <Type>BOOL</Type>
-        <Comment> Error </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERROR;
-	field: ZNAM NO ERROR ;
-	field: ONAM ERROR PRESENT ;
-	io: o;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iErrorCode</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ErrMsg;
-	io: o;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xLog</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>792</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: LOGGER;
-	io: io;
-	field: ZNAM OFF ;
-	field: ONAM ON ;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">ST_VGC</Name>
-      <BitSize>2944</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">ST_ValveBase</ExtendsType>
-      <SubItem>
-        <Name>xDP_OK</Name>
-        <Type>BOOL</Type>
-        <Comment> Indicates the valve can be opened because the differential pressure is low enough</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: DP_OK;
-	field: ZNAM DP NOT OK ;
-	field: ONAM DP OK ;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rAT_VAC_SP</Name>
-        <Type>REAL</Type>
-        <Comment> Interlock setpoint for gauges on both sides of valve</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
-        <Default>
-          <Value>1E-06</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: AT_VAC_SP;
-	io: o;
-	field: HOPR 1000
-	field: LOPR 0
-	field: PREC 2
-	field: EGU "TORR"
-	autosave_pass1: VAL DESC
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rAT_VAC_SP_LAST</Name>
-        <Type>REAL</Type>
-        <Comment> Interlock setpoint for gauges on both sides of valve</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
-        <Default>
-          <Value>1E-06</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rAT_VAC_HYS</Name>
-        <Type>REAL</Type>
-        <Comment> Hysteresis of the vacuum sp</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-        <Default>
-          <Value>1E-06</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: AT_VAC_HYS;
-	io: o;
-	field: HOPR 1000
-	field: LOPR 0
-	field: PREC 2
-	field: EGU "TORR"
-	autosave_pass1: VAL DESC
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rHYST_PERC</Name>
-        <Type>REAL</Type>
-        <Comment> Hysteresis percentage</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>928</BitOffs>
-        <Default>
-          <Value>0.8</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: HYST_PERC ;
-	io: o;
-	autosave_pass1: VAL DESC
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xAT_VAC</Name>
-        <Type>BOOL</Type>
-        <Comment>At vacuum setpoint</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: AT_VAC ; 
-	field: ZNAM NOT AT VAC ;
-	field: ONAM AT VAC ;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xERR_DifPres</Name>
-        <Type>BOOL</Type>
-        <Comment> Alarm Outputs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>968</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERR_DifPres;
-	field: ZNAM NO ERROR ;
-	field: ONAM Diffrential error present ;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xERR_SP</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERR_SP;
-	field: ZNAM NO ERROR ;
-	field: ONAM Setpoint error present ;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xERR_ExtFault</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERR_Ext;
-	field: ZNAM NO ERROR ;
-	field: ONAM External error present ;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xAlmSum</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sDevName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>1000</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sIlkUSDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment>ILK Devices</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1648</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_DEVICE_US;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sIlkDSDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>2296</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_DEVICE_DS;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name>FB_EXT_TREATY_VGC</Name>
-      <BitSize>3008</BitSize>
-      <SubItem>
-        <Name>TREATY_VGC</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
-        <BitSize>2944</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xTREATY_VGC_STATUS</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>ST_EXT_ILK</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>xIlk_sw</Name>
-        <Type>BOOL</Type>
-        <Comment> EPICS control for switching the interlock on or off.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: HV_SW;
-    io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xILK_OK_DO</Name>
-        <Type>BOOL</Type>
-        <Comment> Readout of the external interlock's ouput value</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_DO;
-    io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xIlkOK</Name>
-        <Type>BOOL</Type>
-        <Comment> Interlock Bit</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_OK;
-    io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rPRO_SP</Name>
-        <Type>REAL</Type>
-        <Comment> Pressure below which the HV signal may turn on</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>1E-06</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: PRO_SP;
-    io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name>FB_EXT_ILK</Name>
-      <BitSize>1152</BitSize>
-      <SubItem>
-        <Name>VG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ILK</Name>
-        <Type ReferenceTo="true">ST_EXT_ILK</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xILK_OK_DO</Name>
-        <Type>BOOL</Type>
-        <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name GUID="{944726B1-A958-40A6-B97D-51A67664C20E}" TcBaseType="true" CName="TcEventConfirmationState">TcEventConfirmationState</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
@@ -20912,7 +26778,7 @@ These features aren't disabled, they just aren't used, think child/parent classe
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>81379820</GetCodeOffs>
+        <GetCodeOffs>81382388</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="45">__getnTimestamp</Name>
@@ -21676,11 +27542,13 @@ These features aren't disabled, they just aren't used, think child/parent classe
       <SubItem>
         <Name>schema</Name>
         <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-        <Comment>Message or Alarm{Cleared,Confirmed,Raised} event information
+        <Comment>
+		Message or Alarm{Cleared,Confirmed,Raised} event information
 
 		Note that elements here do not follow the usual Hungarian notation / 
 		variable-type-prefixing naming convention due to the member names being
-		used directly in the generation of the JSON document.</Comment>
+		used directly in the generation of the JSON document.
+	</Comment>
         <BitSize>648</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
@@ -21785,7 +27653,7 @@ These features aren't disabled, they just aren't used, think child/parent classe
       <SubItem>
         <Name>source</Name>
         <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-        <Comment>This is actually: T_MaxString
+        <Comment> This is actually: T_MaxString
  which has been expanded due to requirements for pinning global data types.</Comment>
         <BitSize>2048</BitSize>
         <BitOffs>4168</BitOffs>
@@ -21800,7 +27668,7 @@ These features aren't disabled, they just aren't used, think child/parent classe
       <SubItem>
         <Name>event_type</Name>
         <Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
-        <Comment>This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
+        <Comment> This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
  which has been expanded due to requirements for pinning global data types.</Comment>
         <BitSize>16</BitSize>
         <BitOffs>6224</BitOffs>
@@ -22611,31 +28479,31 @@ These features aren't disabled, they just aren't used, think child/parent classe
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81379436</GetCodeOffs>
+        <GetCodeOffs>81382004</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81379480</GetCodeOffs>
+        <GetCodeOffs>81382048</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81379444</GetCodeOffs>
+        <GetCodeOffs>81382012</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81379468</GetCodeOffs>
+        <GetCodeOffs>81382036</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81379488</GetCodeOffs>
+        <GetCodeOffs>81382056</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -29156,5797 +35024,6 @@ These features aren't disabled, they just aren't used, think child/parent classe
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
-    <DataType>
-      <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>Width</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment> distance between horizontal slits (x)</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Width
-            io: i
-            field: EGU mm</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Height</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment> distance between vertical slits (y)</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Height
-            io: i
-            field: EGU mm</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xOK</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <Comment> status of aperture, false if error or in motion</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: OK
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_PMPS_Aperture</Name>
-      <BitSize>96</BitSize>
-      <ExtendsType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</ExtendsType>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_BeamParams</Name>
-      <BitSize>1760</BitSize>
-      <SubItem>
-        <Name>nTran</Name>
-        <Type>REAL</Type>
-        <Comment>  Requested pre-optic attenuation %  </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Transmission
-            io: i
-			field: HOPR 1;
-			field: LOPR 0;
-			field: PREC 2;
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRate</Name>
-        <Type>UDINT</Type>
-        <Comment> Pulse-rate </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Rate
-            io: i
-            field: EGU Hz
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neVRange</Name>
-        <Type>DWORD</Type>
-        <Comment> Photon energy ranges </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: eVRanges
-            io: i
-            field: EGU eV</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>binary</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neV</Name>
-        <Type>REAL</Type>
-        <Comment> Photon energy  </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: PhotonEnergy
-            io: i
-            field: EGU eV</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nBCRange</Name>
-        <Type>WORD</Type>
-        <Comment> Beamclass ranges </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: BeamClassRanges
-            io: i</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>binary</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nBeamClass</Name>
-        <Type>USINT</Type>
-        <Comment> Beamclass </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: BeamClass
-            io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMachineMode</Name>
-        <Type>USINT</Type>
-        <Comment> Machine Mode </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: MachineMode
-            io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astAttenuators</Name>
-        <Type Namespace="PMPS">ST_PMPS_Attenuator</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Beamline attenuators </Comment>
-        <BitSize>1024</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: AuxAtt
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>aVetoDevices</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Stoppers </Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>1184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Veto
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astApertures</Name>
-        <Type Namespace="PMPS">ST_PMPS_Aperture</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>4</Elements>
-        </ArrayInfo>
-        <Comment> Apertures </Comment>
-        <BitSize>384</BitSize>
-        <BitOffs>1312</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>[1].Width</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[1].Height</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[2].Width</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[2].Height</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[3].Width</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[3].Height</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[4].Width</Name>
-            <Value>1000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[4].Height</Name>
-            <Value>1000</Value>
-          </SubItem>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Apt
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xValidToggle</Name>
-        <Type>BOOL</Type>
-        <Comment> Toggle for watchdog</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xValid</Name>
-        <Type>BOOL</Type>
-        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Valid
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCohortInt</Name>
-        <Type>UDINT</Type>
-        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Cohort
-        io: i
-            field: DESC Cohort inc on each arb cycle
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">I_HigherAuthority</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID to remove</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestBP</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID of state requesting beam parameter set</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stReqBP</Name>
-          <Comment>Requested beam params</Comment>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">I_LowerAuthority</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getnLowerAuthorityID</Name>
-        <ReturnType RpcDirection="out">DWORD</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>ElevateRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>HigherAuthority</Name>
-          <Type Namespace="PMPS">I_HigherAuthority</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
-      <BitSize>2464</BitSize>
-      <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
-      <SubItem>
-        <Name>nId</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1760</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: ID
-		io: i
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LiveInTable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Live
-		io: i
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDevName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>1800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Device
-		io: i
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">T_HashTableEntry</Name>
-      <Comment> Hash table entry </Comment>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <Comment> Entry key: 32 bit unsigned integer or pointer </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>lock</Name>
-        <Type>DWORD</Type>
-        <Comment> Node state flags: Bit 0 &lt;0..1&gt;: 0 = node free, 1 = node in use, other bits reserved </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pNext</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Pointer to next hash table element </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pNextFree</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Pointer to next free element </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pNextGlob</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Pointer to next global element </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">T_HHASHTABLE</Name>
-      <Comment> Hash table object handle </Comment>
-      <BitSize>3488</BitSize>
-      <SubItem>
-        <Name>nCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Number of used hash table entries </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nFree</Name>
-        <Type>UDINT</Type>
-        <Comment> Number of free hash table entries </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>pEntries</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <Comment> Pointer to table array </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>cbEntries</Name>
-        <Type>UDINT</Type>
-        <Comment> Byte size of table array </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nElements</Name>
-        <Type>UDINT</Type>
-        <Comment> Number of table/array elements </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>cbElement</Name>
-        <Type>UDINT</Type>
-        <Comment> Byte size of one array element </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pEntrys</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>101</Elements>
-        </ArrayInfo>
-        <BitSize>3232</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pFreeEntrys</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>3424</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pFirstEntry</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>3456</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">FB_HashTableCtrl</Name>
-      <Comment> Hash table control function block </Comment>
-      <BitSize>352</BitSize>
-      <SubItem>
-        <Name>hTable</Name>
-        <Type Namespace="Tc2_Utilities" ReferenceTo="true">T_HHASHTABLE</Type>
-        <Comment> Hash table handle variable </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <Comment> Entry key: 32 bit unsigned integer or pointer, used by A_Lookup, A_Remove method, the key.lookup variable is also used by A_Add method </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>putValue</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>putPosPtr</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <Comment> Hash table entry position pointer, used by A_GetNext </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bOk</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE = success, FALSE = error </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getValue</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Entry value: 32/64 bit unsigned integer or pointer </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getPosPtr</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <Comment> returned by A_GetFirstEntry, A_GetNextEntry, A_Add, A_Lookup and A_Remove method </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>p</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>n</Name>
-        <Type Namespace="Tc2_Utilities" PointerTo="1">T_HashTableEntry</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nHash</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
-        <Name>A_RemoveAll</Name>
-      </Action>
-      <Action>
-        <Name>A_GetNext</Name>
-      </Action>
-      <Action>
-        <Name>A_GetIndexAtPosPtr</Name>
-      </Action>
-      <Action>
-        <Name>A_Add</Name>
-      </Action>
-      <Action>
-        <Name>A_Remove</Name>
-      </Action>
-      <Action>
-        <Name>A_GetFirst</Name>
-      </Action>
-      <Action>
-        <Name>A_RemoveFirst</Name>
-      </Action>
-      <Action>
-        <Name>A_Lookup</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">FB_BeamParamAssertionPool</Name>
-      <Comment> This function block implements simple database. Data element values are stored in the hash table.  </Comment>
-      <BitSize>214336</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <Comment> Entry key: used by A_Lookup, A_Remove method, the key variable is also used by A_Add method </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>putPosPtr</Name>
-        <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
-        <Comment> Hash table entry position pointer (used by A_Find, A_GetNext, A_GetPrev) </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>putValue</Name>
-        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-        <Comment> Hash table entry value (used by A_AddHead, A_AddTail, A_Find )</Comment>
-        <BitSize>2464</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bOk</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE = Success, FALSE = Failed </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2560</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getPosPtr</Name>
-        <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
-        <Comment> Returned hash table entry position pointer </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2592</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getValue</Name>
-        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-        <Comment> Returned hash table entry value </Comment>
-        <BitSize>2464</BitSize>
-        <BitOffs>2624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Hash table size (number of used entries, used by A_Count) </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>5088</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>epicsDataPool</Name>
-        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>20</Elements>
-        </ArrayInfo>
-        <Comment> Structured data element pool for display in EPICS</Comment>
-        <BitSize>49280</BitSize>
-        <BitOffs>5120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Entry
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>dataPool</Name>
-        <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>61</Elements>
-        </ArrayInfo>
-        <Comment> Structured data element pool </Comment>
-        <BitSize>150304</BitSize>
-        <BitOffs>54400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>entries</Name>
-        <Type Namespace="PMPS">T_HashTableEntry</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>61</Elements>
-        </ArrayInfo>
-        <Comment> Max. number of hash table entries. The value of table entry = 32 bit integer (pointer to dataPool-array-entry) </Comment>
-        <BitSize>3904</BitSize>
-        <BitOffs>204704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbTable</Name>
-        <Type Namespace="Tc2_Utilities">FB_HashTableCtrl</Type>
-        <Comment> basic hash table control function block </Comment>
-        <BitSize>352</BitSize>
-        <BitOffs>208608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>hTable</Name>
-        <Type Namespace="Tc2_Utilities">T_HHASHTABLE</Type>
-        <Comment> hash table handle </Comment>
-        <BitSize>3488</BitSize>
-        <BitOffs>208960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pRefPtr</Name>
-        <Type Namespace="PMPS" PointerTo="1">ST_BP_ArbInternal</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>212448</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>indexOfElem</Name>
-        <Type>ULINT</Type>
-        <Comment> Integer value (max. size: x86=&gt;32bit, x64=&gt;64bit)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>212480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>cstSafeBeam</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> MG </Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>212544</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.nTran</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.neVRange</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nRate</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nBCRange</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
-        <Name>A_Count</Name>
-      </Action>
-      <Action>
-        <Name>DataPoolToEpics</Name>
-      </Action>
-      <Action>
-        <Name>A_Add</Name>
-      </Action>
-      <Action>
-        <Name>A_Remove</Name>
-      </Action>
-      <Action>
-        <Name>A_GetFirst</Name>
-      </Action>
-      <Action>
-        <Name>A_GetNext</Name>
-      </Action>
-      <Action>
-        <Name>A_Lookup</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>no_check</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">FB_Arbiter</Name>
-      <Comment> FB Arbiter
-A. Wallace 2020-6-26
-
-The arbiter primary objectives are:
-- Provide a simple interface for devices to request beam parameter sets
-- Provide a way for devices to verify their BPS is active in the arbiter
-- Provide a way for devices remove their requests from evaluation
-- Evaluate all active beam parameter requests registered with the aribiter,
-to determine the safest combination of all sets, provide this set as an output.
-- Do all of this with minimal overhead
-
-To these ends, the arbiter uses a hash-table, the rows being a state-id as the key, and a corresponding
- beam parameter set to be evaluated against all the other sets (or rows), in the table.
- 
-The hash table can be thought of as an array on steriods, they are worth reading about, suffice to say
-the hash table will tell you when you reach the end of all the entries, and enables us to find entries quickly.
-
-These features efficiently address the addition, removal, and verification of beam parameter sets listed in the above requirements.
-</Comment>
-      <BitSize>474624</BitSize>
-      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
-      <Implements Namespace="PMPS">I_LowerAuthority</Implements>
-      <SubItem>
-        <Name>nRequestsCount</Name>
-        <Type>UDINT</Type>
-        <Comment> How many requests are currently in the arbiter</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbBPAssertionPool</Name>
-        <Type Namespace="PMPS">FB_BeamParamAssertionPool</Type>
-        <Comment>Table of active beam parameter assertions</Comment>
-        <BitSize>214336</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: AP
-        io: i
-        field: DESC Assertion Pool
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xRequestMade</Name>
-        <Type>BOOL</Type>
-        <Comment> Arbiter has confirmed its request has made it into the beam parameter request    </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>214464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nArbiterID</Name>
-        <Type>UDINT</Type>
-        <Comment> Arbiter ID, used for making higher-level BP requests</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ArbiterID
-        io: i
-        field: DESC Arbiter ID for elev. req.
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nNextCohort</Name>
-        <Type>UDINT</Type>
-        <Comment> The cohort ID any new requests will adopt, will become ReqInProgCohort at the start of the next acknowledgement cycle</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214528</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nAckInProgCohort</Name>
-        <Type>UDINT</Type>
-        <Comment> The cohort ID currently being acknowledged, will become nActiveCohort after acknowledgement from HA</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214560</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveCohort</Name>
-        <Type>UDINT</Type>
-        <Comment> Requests with cohorts &lt;= to this value will be considered active in CheckRequest</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214592</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: CohortCounter
-        io: i
-        field: DESC Intrnl cohort counter
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bStartNewAckRequest</Name>
-        <Type>BOOL</Type>
-        <Comment> Set by an add or remove method call, triggers an ack cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>214624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAckInProgress</Name>
-        <Type>BOOL</Type>
-        <Comment> Set by ElevateReq when there is a new ack request and reset when the ack cycle is complete</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>214632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>idTransmission</Name>
-        <Type>DWORD</Type>
-        <Comment> ID of BP limiting transmission</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>idRate</Name>
-        <Type>DWORD</Type>
-        <Comment> ID of BP limiting rate</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>214688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>214720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sArbName</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>216768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InfoStringFmtr</Name>
-        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-        <BitSize>7840</BitSize>
-        <BitOffs>218816</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bVerbose</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>226656</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>q_stBeamParams</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment>Updated on each cycle of the arbiter FB with the current arbitrated beam parameter set</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>226688</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ArbitratedBP
-        io: i
-        field: DESC Arbitrated BP
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xStateIDFound</Name>
-        <Type>BOOL</Type>
-        <Comment>Set true if a state-id is found in the assertion pool after calling A_VerifyAssertion</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>228448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>__GETARBITRATEDBP__XFIRSTPASS</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>228456</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>__GETARBITRATEDBP__FBGETCURTASKIDX</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>228480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>__GETARBITRATEDBP__LASTCYCLECOUNT</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>228608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>__GETARBITRATEDBP__FBLOGMESSAGE</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>81984</BitSize>
-        <BitOffs>228672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>__ADDREQUEST__FBLOG</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>81984</BitSize>
-        <BitOffs>310656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>__REMOVEREQUEST__FBLOG</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>81984</BitSize>
-        <BitOffs>392640</BitOffs>
-      </SubItem>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>ElevateRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>HigherAuthority</Name>
-          <Type Namespace="PMPS">I_HigherAuthority</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArbitratedBP</Name>
-        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
-        <ReturnBitSize>1760</ReturnBitSize>
-        <Local>
-          <Name>getPosPtr</Name>
-          <Type Namespace="PMPS" PointerTo="1">T_HashTableEntry</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>getBPStructInt</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-        <Local>
-          <Name>stOutputBP</Name>
-          <Comment>Holding struct for arbitration process</Comment>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-        <Local>
-          <Name>xFirstPass</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__XFIRSTPASS</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>fbGetCurTaskIdx</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__FBGETCURTASKIDX</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>LastCycleCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__LASTCYCLECOUNT</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>fbLogMessage</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81984</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__FBLOGMESSAGE</Value>
-            </Property>
-          </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>ArbitrateBP</Name>
-        <ReturnType Namespace="PMPS">ST_BP_ArbInternal</ReturnType>
-        <ReturnBitSize>2464</ReturnBitSize>
-        <Parameter>
-          <Name>stBP1</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stBP2</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Parameter>
-        <Local>
-          <Name>idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>bcBitmask</Name>
-          <Type>WORD</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__getnLowerAuthorityID</Name>
-        <ReturnType RpcDirection="out">DWORD</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nLowerAuthorityID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>AddRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment> Unique ID within aribter for the request. Make sure this is unique for every device + state combination</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stReqBP</Name>
-          <Comment>Requested beam params</Comment>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>sDevName</Name>
-          <Comment> Name of the device making the request</Comment>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-        <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81984</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__ADDREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81984</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestBP</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID of state requesting beam parameter set</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stReqBP</Name>
-          <Comment>Requested beam params</Comment>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
-      <BitSize>1760</BitSize>
-      <SubItem>
-        <Name>nTran</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment TxtId="">Requested pre-optic attenuation - 1 is full transmission</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Min>0</Min>
-          <Max>1</Max>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Attenuation
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRate</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <Comment> Pulse-rate </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>120</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Rate
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neVRange</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <Comment> Photon energy ranges </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>4294967295</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: PhotonEnergy
-        io: i</Value>
-          </Property>
-          <Property>
-            <Name>plcAttribute_displaymode</Name>
-            <Value>binary</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neV</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment TxtId="">Current Photon energy as calculated by the arbiter</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nBCRange</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000004}">WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Min>0</Min>
-          <Max>65535</Max>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nBeamClass</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Default>
-          <Min>0</Min>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nMachineMode</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astAttenuators</Name>
-        <Type GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Beamline attenuators </Comment>
-        <BitSize>1024</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: AuxAttenuator
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astApertures</Name>
-        <Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>4</Elements>
-        </ArrayInfo>
-        <BitSize>384</BitSize>
-        <BitOffs>1184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>aVetoDevices</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Stopper statuses </Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>1568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: AuxAttenuator
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xValidToggle</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <Comment> Toggle for watchdog</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xValid</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Valid
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCohortInt</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Attenuation
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Hides>
-        <Hide GUID="{ADE62DDD-CAE3-4FE3-BE11-F358D7D0CDD8}"/>
-        <Hide GUID="{729DFDAA-EB68-494E-B247-D86DA3C0AE5E}"/>
-        <Hide GUID="{41059C79-1015-4C2C-AFF4-697A824775D7}"/>
-        <Hide GUID="{80E871EC-0C36-49B0-AD5D-F1F0FB351299}"/>
-        <Hide GUID="{5FC92061-002A-45B0-B954-CD8F28B5CE49}"/>
-        <Hide GUID="{C64C88BE-2BD8-4AC6-ACD6-2A08570B4923}"/>
-        <Hide GUID="{B472A77E-9430-445F-AD24-21E649F6ACD1}"/>
-        <Hide GUID="{559ADF00-CB27-4B7D-8DEA-9DBCF390B12B}"/>
-        <Hide GUID="{E1A510FA-6CE5-40B2-9617-7C29C5B7C692}"/>
-        <Hide GUID="{3F6D5E74-4433-4A11-8ADE-14BBEED361D6}"/>
-        <Hide GUID="{6E597FBD-95E0-4E3A-8361-F15F77CF10FA}"/>
-        <Hide GUID="{5F9FBCD0-8C11-4386-87CB-253F17D55690}"/>
-        <Hide GUID="{5F9FBCD0-8C11-4386-87CB-253F17D55690}"/>
-        <Hide GUID="{F4D82764-2299-4BB7-86C4-99ED0EBA5A76}"/>
-        <Hide GUID="{1E08C18A-0551-4C52-916A-1A7A2B58BA24}"/>
-        <Hide GUID="{1E08C18A-0551-4C52-916A-1A7A2B58BA24}"/>
-        <Hide GUID="{0C6A4924-E177-45F6-9AB0-6F9DB98D3474}"/>
-        <Hide GUID="{7BACB0F9-4BD8-4ADE-B8B1-2D069E1D0190}"/>
-        <Hide GUID="{C338245C-50EC-4E6D-B363-9DA04BB5DFA5}"/>
-        <Hide GUID="{0E623A01-D6F4-41DD-A8F2-FBC77EE11035}"/>
-        <Hide GUID="{B8136069-15B2-4545-8E40-00504F2F580D}"/>
-        <Hide GUID="{4A38F9D3-765E-4C94-9AAB-7EB5DFA13820}"/>
-        <Hide GUID="{C9AB5DB1-1B57-42EF-8E17-FBE97768475C}"/>
-        <Hide GUID="{43851ABC-CF8A-4AF9-A768-E27D209879D8}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">FB_VetoArbiter</Name>
-      <BitSize>27168</BitSize>
-      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
-      <SubItem>
-        <Name>bVeto</Name>
-        <Type>BOOL</Type>
-        <Comment> Rising edge clears request, hold true to veto continuously, falling edge restores request</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>HigherAuthority</Name>
-        <Type Namespace="PMPS">I_HigherAuthority</Type>
-        <Comment> Typically connected to a higher-level arbiter.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LowerAuthority</Name>
-        <Type Namespace="PMPS">I_LowerAuthority</Type>
-        <Comment> Lower authority to be vetoed</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>FFO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> This should be the FFO upstream of the veto device</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ffKeepItSecretKeepItSafe</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>192</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_xAutoReset</Name>
-            <Value>1</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String>Holds beam off until request is back in arbitration</String>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>200</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_xVetoable</Name>
-            <Value>1</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stStandbyBP</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>25280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtVeto</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>27040</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftVeto</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>27104</BitOffs>
-      </SubItem>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestBP</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID of state requesting beam parameter set</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stReqBP</Name>
-          <Comment>Requested beam params</Comment>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID to remove</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">FB_SubSysToArbiter_IO</Name>
-      <Comment> Use on a subsystem PLC to request from the arbiter
- Run at the top of your cycle to receive the latest BP</Comment>
-      <BitSize>138752</BitSize>
-      <Implements Namespace="PMPS">I_HigherAuthority</Implements>
-      <SubItem>
-        <Name>Reset</Name>
-        <Type>BOOL</Type>
-        <Comment> Fast fault reset</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>72</BitOffs>
-        <Default>
-          <String>SubSysToArbiter</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_bVeto</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Arbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>736</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_stCurrentBP</Name>
-        <Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcLinkTo</Name>
-            <Value>TIIB[PMPS_PRE]^IO Inputs^CurrentBP</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_stRequestedBP</Name>
-        <Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>2560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcLinkTo</Name>
-            <Value>TIIB[PMPS_PRE]^IO Outputs^RequestedBP</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xTxPDO_toggle</Name>
-        <Type>BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>4320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: TxPDO_toggle
-        io: i</Value>
-          </Property>
-          <Property>
-            <Name>TcLinkTo</Name>
-            <Value>TIIB[PMPS_PRE]^SYNC Inputs^TxPDO toggle</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xTxPDO_state</Name>
-        <Type>BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>4321</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: TxPDO_state
-        io: i</Value>
-          </Property>
-          <Property>
-            <Name>TcLinkTo</Name>
-            <Value>TIIB[PMPS_PRE]^SYNC Inputs^TxPDO state</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ffPMPSIO_Disconnect</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> Fast faults</Comment>
-        <BitSize>25088</BitSize>
-        <BitOffs>4352</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String>Arbiter network interface disconnected or not OP</String>
-          </SubItem>
-          <SubItem>
-            <Name>.i_DevName</Name>
-            <String>SubSysToArbiter</String>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nRequestCohort</Name>
-        <Type>UDINT</Type>
-        <Comment> Request cohort</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>29440</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: RequestCohort
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveCohort</Name>
-        <Type>UDINT</Type>
-        <Comment> Active cohort, updated by incoming BP from arbiter PLC, in the ElevateRequest arbiter call</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>29472</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: ActiveCohort
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbVetoArb</Name>
-        <Type Namespace="PMPS">FB_VetoArbiter</Type>
-        <BitSize>27168</BitSize>
-        <BitOffs>29504</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbLog</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>81984</BitSize>
-        <BitOffs>56704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>__CHECKREQUEST__XFIRSTTIME</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>138688</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>__CHECKREQUEST__NID</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>138720</BitOffs>
-      </SubItem>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>xFirstTime</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__CHECKREQUEST__XFIRSTTIME</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>nId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__CHECKREQUEST__NID</Value>
-            </Property>
-          </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>RequestBP</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID of state requesting beam parameter set</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>stReqBP</Name>
-          <Comment>Requested beam params</Comment>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Comment>StateID to remove</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_GaugeBase</Name>
-      <BitSize>85312</BitSize>
-      <SubItem>
-        <Name>fbLogger</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <Comment>Logging </Comment>
-        <BitSize>81984</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.eSubsystem</Name>
-            <Value>1</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ePrevState</Name>
-        <Type Namespace="LCLS_Vacuum">E_PressureState</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>82048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tErrorPresent</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>82080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tAction</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment> Primary action of this device (OPN_DO, etc.)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>82144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tOverrideActivated</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>82208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tState</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>82272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>82336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bRestorePersistentData</Name>
-        <Type>BOOL</Type>
-        <Comment> For Persistent Data</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>82984</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stateTimer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>83008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIdx</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>83232</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbWritePersistentData</Name>
-        <Type Namespace="Tc2_Utilities">WritePersistentData</Type>
-        <BitSize>1600</BitSize>
-        <BitOffs>83360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tRecover</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>84960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rVAC_SP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>85184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rPRO_SP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>85216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rHYS_PR</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>85248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_MKS317</Name>
-      <Comment> This function is for the Pirani MKS 317 connected to a 937A/B 
- This function block is used to provide protection and automatic turn on of ion gauges,
- it also manages the turn on of the AT_VAC boolean, and checks to make sure the pressure is good </Comment>
-      <BitSize>86720</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
-      <SubItem>
-        <Name>b937A</Name>
-        <Type>BOOL</Type>
-        <Comment> True if this gauge is connected to MKS937A controller, False if connected to MKS937B controller</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>85312</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>85344</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: 
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS_R</Name>
-        <Type>INT</Type>
-        <Comment> input Pressure // Link to analog Input</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>86432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rMinPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86464</BitOffs>
-        <Default>
-          <Value>0.0001</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDefaultVAC_SP</Name>
-        <Type>REAL</Type>
-        <Comment> Default 50 mT</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86496</BitOffs>
-        <Default>
-          <Value>0.05</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDisconnectedBoundary</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86528</BitOffs>
-        <Default>
-          <Value>0.1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidLoBoundary</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86560</BitOffs>
-        <Default>
-          <Value>0.22</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidBoundaryMin</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86592</BitOffs>
-        <Default>
-          <Value>0.6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidHiBoundary</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86624</BitOffs>
-        <Default>
-          <Value>9.7</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidHiBoundaryMax</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86656</BitOffs>
-        <Default>
-          <Value>9.9</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rNoSensorBoundary</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86688</BitOffs>
-        <Default>
-          <Value>10</Value>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_MKS275</Name>
-      <Comment> This function block is used to provide protection and automatic turn on of ion gauges,
- it also manages the turn on of the AT_VAC boolean, and checks to make sure the pressure is good 
- For MKS 275 mini-convectron </Comment>
-      <BitSize>86720</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
-      <SubItem>
-        <Name>PG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>85312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: 
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>V</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iTermBits</Name>
-        <Type>UINT</Type>
-        <Comment> The terminal's maximum value in bits</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>86400</BitOffs>
-        <Default>
-          <Value>32767</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>Vlowest</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86432</BitOffs>
-        <Default>
-          <Value>10</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS_R</Name>
-        <Type>INT</Type>
-        <Comment> input Pressure // Link to analog Input</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>86464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>MinPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86496</BitOffs>
-        <Default>
-          <Value>0.0001</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDeadband</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86528</BitOffs>
-        <Default>
-          <Value>0.05</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidLoBoundary</Name>
-        <Type>REAL</Type>
-        <Comment>  0.375V as per manual page 27</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86560</BitOffs>
-        <Default>
-          <Value>0.375</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rValidHiBoundary</Name>
-        <Type>REAL</Type>
-        <Comment> 5.534; // manual page 27</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86592</BitOffs>
-        <Default>
-          <Value>5.659</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDisconnectedBoundary</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86624</BitOffs>
-        <Default>
-          <Value>0.3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDefaultVAC_SP</Name>
-        <Type>REAL</Type>
-        <Comment>Default set point 50 mT</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86656</BitOffs>
-        <Default>
-          <Value>0.05</Value>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Method>
-        <Name>M_SetBits</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TermBits</Name>
-          <Comment> The terminal's maximum value in bits</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>no_check</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_MKS422</Name>
-      <Comment> This function is for the Cold Cathode MKS 422 connected to a 937A/B 
-This function provides ILK and Set Point Protection for the Cold Cathode</Comment>
-      <BitSize>88064</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
-      <SubItem>
-        <Name>PG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment> Pirani Gauge Structure used to Interlock the Cold Cathode</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>85312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>b937A</Name>
-        <Type>BOOL</Type>
-        <Comment> True if this gauge is connected to MKS937A controller, False if connected to MKS937B controller</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>86368</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tRecoverDelay</Name>
-        <Type>TIME</Type>
-        <Comment>Delay Time after the first cycle to start the device. Default is 600S</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86400</BitOffs>
-        <Default>
-          <Value>600000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>IG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment> The Cold Cathode Data Structure</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>86432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: 
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87488</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>timer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>87520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS_R</Name>
-        <Type>INT</Type>
-        <Comment> Controls and I/Os</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>87744</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xHV_DIS</Name>
-        <Type>BOOL</Type>
-        <Comment> Disable Gauge High Voltage when True // 'TcLinkTo' (EL2794) ^Output</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>87760</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>MinPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87776</BitOffs>
-        <Default>
-          <Value>1E-11</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vDisconnected</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87808</BitOffs>
-        <Default>
-          <Value>0.18</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vMaxValid</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87840</BitOffs>
-        <Default>
-          <Value>9.6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vMax</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87872</BitOffs>
-        <Default>
-          <Value>9.9</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vValidLo</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87904</BitOffs>
-        <Default>
-          <Value>0.22</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vMin</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87936</BitOffs>
-        <Default>
-          <Value>0.6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>cDefaultPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87968</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bWasOn</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88000</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecover</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88008</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecoverWrite</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88016</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Recover</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Method>
-        <Name>M_HVE</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>enable</Name>
-          <Comment> set to true to enable, false to disable;</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>M_Recover</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>M_AutoOn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_MKS500</Name>
-      <Comment> This function is for the Cold Cathode MKS 500. If connected to Beckhoff EP boxes.
-Set the EP bit to TRUE, this is necessary for the MKS500-to-EP box interface beacuse the EP
-boxes do not natively support the 5v IO signals on the MKS500 gauge.
-This function provides ILK and Set Point Protection for the Cold Cathode</Comment>
-      <BitSize>88384</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_GaugeBase</ExtendsType>
-      <SubItem>
-        <Name>PG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>85312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEP</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to True if This Gauge is connected to EP BOX and not EL Terminals</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>86368</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tRecoverDelay</Name>
-        <Type>TIME</Type>
-        <Comment>Delay Time after the first cycle to start the device. Default is 600S</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86400</BitOffs>
-        <Default>
-          <Value>600000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>IG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>86432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: 
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87488</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GaugeTurnOnTmr</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>87520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tStartupTimer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>87744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iTermBits</Name>
-        <Type>UINT</Type>
-        <Comment> The terminal's maximum value in bits</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>87968</BitOffs>
-        <Default>
-          <Value>32767</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS_R</Name>
-        <Type>INT</Type>
-        <Comment> Controls and I/Os</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>87984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xHV_DIS</Name>
-        <Type>BOOL</Type>
-        <Comment> Enable High Voltage when True // 'TcLinkTo' (EP2624) ^Output</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>88000</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xHV_ON</Name>
-        <Type>BOOL</Type>
-        <Comment>  True when High Voltage is on  // 'TcLinkTo' (EL1124) ^Input</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>88008</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xDisc_Active</Name>
-        <Type>BOOL</Type>
-        <Comment> Discharge Current Active // 'TcLinkTo' (EL1124) ^Input</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>88016</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>binit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88024</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>pBase</Name>
-        <Type>REAL</Type>
-        <Comment>default curve base pressure is 1E-10. Confusing since can't actually read that low using analog out.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>88032</BitOffs>
-        <Default>
-          <Value>1E-10</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vBase</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88064</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vDisconnected</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88096</BitOffs>
-        <Default>
-          <Value>0.5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vSlope</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88128</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vGaugeOff</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88160</BitOffs>
-        <Default>
-          <Value>9.8</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>vNoDischarge</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88192</BitOffs>
-        <Default>
-          <Value>9.3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>MinPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88224</BitOffs>
-        <Default>
-          <Value>1E-10</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>cDefaultPressure</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDeadband</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88288</BitOffs>
-        <Default>
-          <Value>0.3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bWasOn</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecover</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecoverWrite</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>88336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Recover</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Method>
-        <Name>M_HVE</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>enable</Name>
-          <Comment> set to true to enable, false to disable;</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>M_SetBits</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TermBits</Name>
-          <Comment> The terminal's maximum value in bits</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>M_Recover</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">E_BPTMState</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>Init</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NewTarget</Text>
-        <Enum>1000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>RequestBP</Text>
-        <Enum>1500</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WaitForBP</Text>
-        <Enum>2500</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WaitingForTransitionAssertion</Text>
-        <Enum>2000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WaitingForFinalAssertion</Text>
-        <Enum>3000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Transitioning</Text>
-        <Enum>4000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WaitForFinalBP</Text>
-        <Enum>5000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>CleaningUp</Text>
-        <Enum>6000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Idle</Text>
-        <Enum>10000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Done</Text>
-        <Enum>8000</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Error</Text>
-        <Enum>9000</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_Index</Name>
-      <Comment> Index FB
-A. Wallace 2016-9-3
-
-Why doesn't beckhoff have this as a builtin type?
-
-Use this thing to have a simple indexer with rollover.
-
-</Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>LowerLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValInc</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer increments by this value</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>48</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>UpperLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollover at this value to lower limit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nVal</Name>
-        <Type>INT</Type>
-        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>Dec</Name>
-      </Action>
-      <Action>
-        <Name>Inc</Name>
-      </Action>
-      <Method>
-        <Name>DecVal</Name>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IncVal</Name>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">BeamParameterTransitionManager</Name>
-      <Comment>
-Implements the procedure for safely transitioning between device states.
-
-NOTE:
-The BPTM will throw an error if the arbiter does not have enough space for the transition and new final assertion. 
-
- </Comment>
-      <BitSize>60256</BitSize>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment>Connect to local arbiter</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Name of the device requesting the transition	</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <String>Device</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_TransitionAssertionID</Name>
-        <Type>UDINT</Type>
-        <Comment> Must not be 0 or EXCLUDED_ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>736</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_stTransitionAssertion</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment>Assertion required during transition (always safer than anything inbetween)</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_nRequestedAssertionID</Name>
-        <Type>UDINT</Type>
-        <Comment> Must not be 0 or EXCLUDED_ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2528</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_stRequestedAssertion</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> PMPS_GVL.cstSafeBeam; //Requested assertion, change whenever</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>2560</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.nTran</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.neVRange</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nRate</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nBCRange</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xMoving</Name>
-        <Type>BOOL</Type>
-        <Comment>Provide rising edge when device begins moving &lt;remove&gt;</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>4320</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xDoneMoving</Name>
-        <Type>BOOL</Type>
-        <Comment>Provide rising edge when device is done with a move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>4328</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCurrentBeamParameters</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment>Connect to current beam parameters</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>4352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bRetry</Name>
-        <Type>BOOL</Type>
-        <Comment> Rising edge to cycle back through the BPTM process. Use if something in the process timed out or failed. This will interrupt a current process</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>6112</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment>Rising edge indicating the device is safe to move, use as input to move execute (which requires a rising edge)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>6120</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> Set if some issue occurs within the bptm</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>6128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrId</Name>
-        <Type>UINT</Type>
-        <Comment> Set to non-zero to help understand the error.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>6144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>6160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>6168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTargetAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>6176</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stTargetAssertion</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> Target assertion</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>6208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrentAssertionID</Name>
-        <Type>UDINT</Type>
-        <Comment> ID of last set state (zero until a state is reached)</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>7968</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>xNewBP</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8000</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xTranBP</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFinalBPInArb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFinalBP</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eBPTMState</Name>
-        <Type Namespace="PMPS">E_BPTMState</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>8032</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ePrevState</Name>
-        <Type Namespace="PMPS">E_BPTMState</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>8048</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>xEntry</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rTransition</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8096</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xNewTarget</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bTransAssertionFailed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8168</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFinalAssertionFailed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LogStrBuffer</Name>
-        <Type>STRING(80)</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>41</Elements>
-        </ArrayInfo>
-        <BitSize>26568</BitSize>
-        <BitOffs>8184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LogBuffIdx</Name>
-        <Type Namespace="LCLS_General">FB_Index</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>34752</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.LowerLimit</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.UpperLimit</Name>
-            <Value>40</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nAssrtAttempt</Name>
-        <Type>INT</Type>
-        <Comment> Number of times we have tried asserting a BP set</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>34848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtRetry</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>34880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtError</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>34944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffTimeout</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>35008</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String>Preemptive requests timed out in BPTM</String>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>10</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_xAutoReset</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rtDoneMoving</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>60096</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLatchDoneMoving</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>60160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>60168</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>LogBuffSize</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>60176</BitOffs>
-        <Default>
-          <Value>40</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>cMaxAttempts</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>60192</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>cReqArbCapacity</Name>
-        <Type>UDINT</Type>
-        <Comment> The thought here is, a BPTM needs at most 2 arbiter slots to complete a transition.
-    If we're at capacity, it means some BPTM before this one has begun a transition,
-    and will require at least one more arbiter spot to complete. 
-    </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>60224</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>AuthorizeTransition</Name>
-      </Action>
-      <Action>
-        <Name>WaitingForFinalAssertion_DO</Name>
-      </Action>
-      <Action>
-        <Name>NewTarget_ENTRY</Name>
-      </Action>
-      <Action>
-        <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
-      </Action>
-      <Action>
-        <Name>WaitingForTransitionAssertion_DO</Name>
-      </Action>
-      <Action>
-        <Name>RemoveTransitionAssertion</Name>
-      </Action>
-      <Action>
-        <Name>SetNewTarget</Name>
-      </Action>
-      <Action>
-        <Name>RequestBP_DO</Name>
-      </Action>
-      <Action>
-        <Name>WaitingForTransitionAssertion_EXIT</Name>
-      </Action>
-      <Action>
-        <Name>WaitingForFinalAssertion_EXIT</Name>
-      </Action>
-      <Action>
-        <Name>DeauthorizeTransition</Name>
-      </Action>
-      <Method>
-        <Name>LogActions</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>LogStr</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>no_check</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_VGC</Name>
-      <Comment> This function block implements basic functionality for Isolation Gate Valves
- This function block interlock is as follows:
-1. The valve can be opened when the difference between the pressures on both sides is
-less than the maximum differential pressure.
-2. This rule persists until the pressures on both sides are lower than the vacuum-setpoint.
-3. Once at-vac, the valve will close if the pressure on either side rises above the setpoint.
-This function block also implements PMPS and EPS interlocks, as well as Fast MPS trigger</Comment>
-      <BitSize>177344</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_Valve</ExtendsType>
-      <SubItem>
-        <Name>i_stUSG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment>Upstream Gauge, usually ion gauge</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>82304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_stDSG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment>Downstream Gauge, usually ion gauge</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>83360</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xDis_DPIlk</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to true when calling the function to disable the differential pressure interlock </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84416</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: Dis_DPIlk
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xPMPS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>Set to True To switch off the bptm and PMPS Arbiter</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84424</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xEPS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>External EPS interlock, Set to TRUE when no EPS interlock is required, otherwise set to correct interlock signal</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84432</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: EPS_OK
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xExt_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>Other External Interlock, Set to True when no external interlock is required. If this Valve is neigboring a Fast Shutter this should be linked to the fast shutter xVAC_FAULT_OK</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84440</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>To be linked to global override bit. This Overrides Vacuum logic only, EPS, MPS and PMPS are still enforces</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset fault</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: FF_Reset
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xIsAperture</Name>
-        <Type>BOOL</Type>
-        <Comment> Set tp True if this is an Aperture Valve, the MPS Fault will trip only when moving.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>84464</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_sDevName</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <Comment> Device name for diagnostic</Comment>
-        <BitSize>2048</BitSize>
-        <BitOffs>84472</BitOffs>
-        <Default>
-          <String>VGC</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_nTransitionRootID</Name>
-        <Type>UDINT</Type>
-        <Comment>A unique transition Root ID that is equal to or greater than 1000</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>86528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iq_stValve</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
-        <Comment> All valve data and states will be in this struct</Comment>
-        <BitSize>2944</BitSize>
-        <BitOffs>86560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv:
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xMPS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>MPS Fast OK, is set when the Valve is Open</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89504</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: MPS_FAULT_OK
-	field: ZNAM MPS FAULT ;
-	field: ONAM MPS OK ;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>io_fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>89536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>89568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>old_input_assignments</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xPMPS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>PMPS interlock</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89600</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: MPS_OK
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoving</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tBPTMtimeout</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>89632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bptm</Name>
-        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
-        <BitSize>60256</BitSize>
-        <BitOffs>89856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FFO</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>150112</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String>Fault occurs when the valve is not in open state</String>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>4112</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type>STRING(80)</Type>
-        <Comment>g_FastFaultOutput1	:	FB_HardwareFFOutput;	</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>175200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rDiffPressAllowed</Name>
-        <Type>REAL</Type>
-        <Comment> Torr, Default value comes from Vat Valve Manual</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>175872</BitOffs>
-        <Default>
-          <Value>22.5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rDiffPress</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>175904</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>set</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>175936</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>reset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>175944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstPass</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>175952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbFSInit</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>175968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDelOK</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>176032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtOK</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>176256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonOvrd</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>176320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtOpen</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>176544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftClose</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>176608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tDelOK</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>176672</BitOffs>
-        <Default>
-          <Value>60000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tOvrd</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>176704</BitOffs>
-        <Default>
-          <Value>10000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tTimeOutDuration</Name>
-        <Type>TIME</Type>
-        <Comment> Timeouts</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>176736</BitOffs>
-        <Default>
-          <Value>30000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tOPNtimeout</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>176768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tCLStimeout</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>176992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>i_xOpnLS</Name>
-        <Type>BOOL</Type>
-        <Comment>IO</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>177216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xClsLS</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>177224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xOPN_DO</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>177232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eVGCPrevState</Name>
-        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
-        <Comment> For logging</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>177248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rAT_VAC_SP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>177280</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rHYST_PERC</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>177312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>ACT_IO</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Action>
-        <Name>ACT_ResetAlarms</Name>
-      </Action>
-      <Action>
-        <Name>ACT_PMPS</Name>
-      </Action>
-      <Method>
-        <Name>M_IsClosed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>M_IsOpen</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>M_Set_OPN_SW</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>no_check</Name>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">ST_VFS</Name>
-      <BitSize>2128</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">ST_ValveBase</ExtendsType>
-      <SubItem>
-        <Name>i_xTrigger</Name>
-        <Type>BOOL</Type>
-        <Comment> Interlock </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: TRIG; 
-	field: ZNAM TRIG_OFF; 
-	field: ONAM TRIG_ON;
-	io: i ;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xCLS_SW</Name>
-        <Type>BOOL</Type>
-        <Comment>external open signal e.g epics</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>808</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: CLS_SW; 
-	field: ZNAM FALSE; 
-	field: ONAM CLOSE;
-	io: io ;
-	</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xERR_ExtFault</Name>
-        <Type>BOOL</Type>
-        <Comment> Alarm Outputs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>816</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERR_Ext;
-	field: ZNAM NO ERROR ;
-	field: ONAM External error present ;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xVAC_FAULT_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: VAC_FAULT_OK; 
-	field: ZNAM FAULT ; 
-	field: ONAM FAULT OK;
-	io: i ;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sGFS</Name>
-        <Type>STRING(80)</Type>
-        <Comment>ILK Devices</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: GFS;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sVetoDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>1480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: VETO_DEVICE;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_VFS_Interface</Name>
-      <Comment>Used as soft IO mapping to create a psuedo valve to communicate over two task on the same PLC.
-for FAST shutter control</Comment>
-      <BitSize>89344</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_Valve</ExtendsType>
-      <SubItem>
-        <Name>IG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment> The MKS422 Cold Cathode Data Structure</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>82304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Veto_Valve</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VGC</Type>
-        <Comment> The VGC structure for the Veto Valve</Comment>
-        <BitSize>2944</BitSize>
-        <BitOffs>83360</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iq_stValve</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VFS</Type>
-        <Comment> All valve data and states will be in this struct</Comment>
-        <BitSize>2128</BitSize>
-        <BitOffs>86304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xVAC_FAULT_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>88432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtTriggerVetoed</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>88448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTriggered</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>88512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonOvrd</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>88576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tOvrd</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>88800</BitOffs>
-        <Default>
-          <Value>10000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rtOK</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>88832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDelOK</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>88896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xOPN_OK</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89120</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tDelOK</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>89152</BitOffs>
-        <Default>
-          <Value>60000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>q_xPRESS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>outputs</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xOPN_SW</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xCLS_SW</Name>
-        <Type>BOOL</Type>
-        <Comment>external open signal e.g epics</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xVAC_FAULT_Reset</Name>
-        <Type>BOOL</Type>
-        <Comment>Valve Vacuum OK, is set to False when there is Vacuum Fault</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>To be linked to global override bit. This Overrides Vacuum logic only, EPS, MPS and PMPS are still enforces</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xOverrideOpen</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xVetoValveOpenDO</Name>
-        <Type>BOOL</Type>
-        <Comment>VETO Devices</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xVetoValveClosed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xTrigger</Name>
-        <Type>BOOL</Type>
-        <Comment>inputs</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xVFS_Open</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xVFS_Closed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>89264</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xMPS_OK</Name>
-        <Type>BOOL</Type>
-        <Comment>MPS Fault OK, is set when the Valve is Open and there is no trigger</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>89272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: MPS_FAULT_OK
-	field: ZNAM MPS FAULT ;
-	field: ONAM MPS OK ;
-	io: i ;
-	</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_eVFS_State</Name>
-        <Type Namespace="LCLS_Vacuum">E_VGC</Type>
-        <Comment>Interface</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>89280</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">E_PumpState</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>pumpSTOPPED</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>pumpSTARTING</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>pumpRUNNING</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>pumpFAULT</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>pumpSTOPPING</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_Pump</Name>
-      <BitSize>82624</BitSize>
-      <SubItem>
-        <Name>fbLogger</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <Comment> For logging</Comment>
-        <BitSize>81984</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.eSubsystem</Name>
-            <Value>1</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ePrevState</Name>
-        <Type Namespace="LCLS_Vacuum">E_PumpState</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>82048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tErrorPresent</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>82080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tAction</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment> Primary action of this device (OPN_DO, PUMP_RUN, etc.)	</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>82144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tFault</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>82208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tILK</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>82272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bRestorePersistentData</Name>
-        <Type>BOOL</Type>
-        <Comment> For Persistent Data</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>82496</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rBackingPressureSP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>82528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rInletPressureSP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>82560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">ST_PIP</Name>
-      <BitSize>1600</BitSize>
-      <SubItem>
-        <Name>xILKOk</Name>
-        <Type>BOOL</Type>
-        <Comment> Read back 
- 	i_xHVisON : BOOL; 
- Interlock </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_OK;
-	field: ZNAM NOT OK ;
-	field: ONAM OK ;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ERROR;
-	field: ZNAM FALSE ;
-	field: ONAM TRUE ;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rHVEna_SP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0.0001</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: AT_VAC_SP;
-	io: io;
-	field: HOPR 1000
-	field: LOPR 0
-	field: PREC 2
-	field: EGU "TORR"
-	autosave_pass1: VAL DESC
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sIlkDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: ILK_DEVICE;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type>STRING(80)</Type>
-        <Comment>Required for other devices using this gauge as interlock</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xHVEna_SW</Name>
-        <Type>BOOL</Type>
-        <Comment> EPICS Controls </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1360</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: HV_SW;
-	io: io;
-	field: ZNAM OFF; 
-	field: ONAM ON;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xAutoOn</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1368</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: Auto_On;
-	field: ZNAM FALSE; 
-	field: ONAM TRUE;
-	io:io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iAutoOnTimer</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1376</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: AutoOn_timer;
-	io:i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment> Shows the override status of this valve </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: OVRD_ON ;
-	field: ZNAM Override OFF ;
-	field: ONAM Override ON;
-	io: io;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pv_xOvrdStart</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: FORCE_START;
-	io: io;
-	field: ZNAM FALSE;
-	field: ONAM FORCE START;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rHYS_PR</Name>
-        <Type>REAL</Type>
-        <Comment> Protection setpoint hysteresis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1408</BitOffs>
-        <Default>
-          <Value>0.001</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: SP_HYS;
-	io: io;
-	field: HOPR 1000
-	field: LOPR 0
-	field: PREC 2
-	field: EGU "TORR"
-	autosave_pass1: VAL DESC
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iOffset</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1440</BitOffs>
-        <Default>
-          <Value>13</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: AI_Offset;
-	io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bOutputInverted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: Inverted;
-	field: ZNAM NORMAL; 
-	field: ONAM INVERTED;
-	io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_xHVEna_DO</Name>
-        <Type>BOOL</Type>
-        <Comment> Enable High Voltage when True // 'TcLinkTo' (EL1124) ^Input</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: HV_DO;
-	field: ZNAM OFF; 
-	field: ONAM ON;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rPRESS</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: PRESS;
-	field: HOPR 1000
-	field: LOPR 0
-	field: PREC 2
-	field: EGU "TORR"
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1504</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: PRESS_AI;
-	io: i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xHV_DI</Name>
-        <Type>BOOL</Type>
-        <Comment> NO contact // 'TcLinkTo' (EL1004) ^Input</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: HV_DI;
-	field: ZNAM FALSE; 
-	field: ONAM TRUE;
-	io:i;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="LCLS_Vacuum">E_PumpState</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1552</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-	pv: STATE;
-	field: ZRST STOPPED;
-	field: ONST STARTING;
-	field: TWST RUNNING;
-	field: THST FAULT;
-	field: FRST STOPPING;
-	io: i;
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xLog</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1568</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: LOGGER;
-	io: io;
-	field: ZNAM OFF ;
-	field: ONAM ON ;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_Vacuum">FB_PIP_Gamma</Name>
-      <Comment> This function block does basic controls FOR the ION pump connected to a Gamma QPCe controller.
- Provides interlocking interface. Enable HV only when interlock gauge press is less than 1.0E-4 Torr </Comment>
-      <BitSize>90624</BitSize>
-      <ExtendsType Namespace="LCLS_Vacuum">FB_Pump</ExtendsType>
-      <SubItem>
-        <Name>i_stGauge</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment>Ion or Pirani gauge for pump interlock</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>82624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>To be linked to global override bit. This Overrides Vacuum interlock logic</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>83680</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tRecoverDelay</Name>
-        <Type>TIME</Type>
-        <Comment>Delay Time after the first cycle to start the device. Default is 900S</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>83712</BitOffs>
-        <Default>
-          <Value>900000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPump</Name>
-        <Type Namespace="LCLS_Vacuum">ST_PIP</Type>
-        <Comment>Gamma Ion pump structure</Comment>
-        <BitSize>1600</BitSize>
-        <BitOffs>83744</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv: 
-	</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_IG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <Comment>When ion pump is used as a measuring device for interlocking gate valves</Comment>
-        <BitSize>1056</BitSize>
-        <BitOffs>85344</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rPRESS</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>86432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>timer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>86464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>q_xHVEna_DO</Name>
-        <Type>BOOL</Type>
-        <Comment> Enable High Voltage when TRUE</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>86688</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_iPRESS</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>86704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xSP_DI</Name>
-        <Type>BOOL</Type>
-        <Comment> NO contact //function of relay set on the QPC to HV output state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>86720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tTimeOutAction</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <Comment> For logging</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>86752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tOverrideActivated</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>86816</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tPumpStartTimeout</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Timeout pump start if pressure &lt; 1E-11 for more than 10s.</Comment>
-        <BitSize>224</BitSize>
-        <BitOffs>86880</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <Value>10000</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>MinPressure</Name>
-        <Type>REAL</Type>
-        <Comment> Minimum readback pressure, pump must register pressure above this to be considered running</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>87104</BitOffs>
-        <Default>
-          <Value>1E-11</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stateTimer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>87136</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonOvrd</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment>Overrides</Comment>
-        <BitSize>224</BitSize>
-        <BitOffs>87360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDelOK</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>87584</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtOK</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>87808</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tOvrd</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>87872</BitOffs>
-        <Default>
-          <Value>10000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>87904</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIdx</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>88576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbWritePersistentData</Name>
-        <Type Namespace="Tc2_Utilities">WritePersistentData</Type>
-        <BitSize>1600</BitSize>
-        <BitOffs>88704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tRecover</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>90304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rDefaultHVEna_SP</Name>
-        <Type>REAL</Type>
-        <Comment> Default protection setpoint as per the gamma QPCe manual</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>90528</BitOffs>
-        <Default>
-          <Value>0.0001</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rHVEna_SP</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>90560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bWasOn</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>90592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecover</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>90600</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoRecoverWrite</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>90608</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcPersistent</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ACT_Logger</Name>
-      </Action>
-      <Action>
-        <Name>ACT_IlkOverride</Name>
-      </Action>
-      <Action>
-        <Name>ACT_SetGauge</Name>
-      </Action>
-      <Action>
-        <Name>IO</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Recover</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Persistent</Name>
-      </Action>
-      <Method>
-        <Name>M_Run</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>run</Name>
-          <Comment> set to true to run, false to stop;</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>M_Recover</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>M_AutoOn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>ST_EXT_GCC</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>xIlk_Inp</Name>
-        <Type>BOOL</Type>
-        <Comment> Report the input signal .</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ILK_INP;
-        io: io;
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name>FB_EXT_TREATY_GAUGE</Name>
-      <BitSize>1184</BitSize>
-      <SubItem>
-        <Name>rTREATY_SIGNAL_PRESS</Name>
-        <Type>REAL</Type>
-        <Comment>	Setpoint agreed upon w/ the external system signified by the signal they send.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rNO_SIGNAL_PRESS</Name>
-        <Type>REAL</Type>
-        <Comment> Presumed pressure if the signal is not received.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>IG</Name>
-        <Type Namespace="LCLS_Vacuum">ST_VG</Type>
-        <BitSize>1056</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv:
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>EXT_IG</Name>
-        <Type>ST_EXT_GCC</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-    pv:
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>i_xEXT_Press_OK</Name>
-        <Type>BOOL</Type>
-        <Comment> Input from AD's system indicating pressure belopw setpoint.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{B59E8DF7-B1DA-497D-9FBF-24C1C4F1954D}" TcSmClass="TComPlcObjDef">
@@ -34975,7 +35052,7 @@ for FAST shutter control</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>FSV_task Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xOpnLS</Name>
             <Comment>IO</Comment>
@@ -34987,7 +35064,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450784</BitOffs>
+            <BitOffs>650862432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xClsLS</Name>
@@ -34999,7 +35076,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450792</BitOffs>
+            <BitOffs>650862440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xTrigger</Name>
@@ -35011,7 +35088,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450832</BitOffs>
+            <BitOffs>650862480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xVetoValveOpenDO</Name>
@@ -35024,7 +35101,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450840</BitOffs>
+            <BitOffs>650862488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xVetoValveClosed</Name>
@@ -35036,7 +35113,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450848</BitOffs>
+            <BitOffs>650862496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xPress_OK</Name>
@@ -35049,7 +35126,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450856</BitOffs>
+            <BitOffs>650862504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xOPN_SW</Name>
@@ -35061,7 +35138,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450864</BitOffs>
+            <BitOffs>650862512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xCLS_SW</Name>
@@ -35074,7 +35151,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450872</BitOffs>
+            <BitOffs>650862520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xVAC_FAULT_Reset</Name>
@@ -35087,7 +35164,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450880</BitOffs>
+            <BitOffs>650862528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xOverrideMode</Name>
@@ -35100,7 +35177,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450888</BitOffs>
+            <BitOffs>650862536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.i_xOverrideOpen</Name>
@@ -35112,14 +35189,14 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665450896</BitOffs>
+            <BitOffs>650862544</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>FSV_task Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutput2.q_xFastFaultOut</Name>
             <BitSize>8</BitSize>
@@ -35138,7 +35215,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664335240</BitOffs>
+            <BitOffs>642843464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xClose_A</Name>
@@ -35150,7 +35227,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450800</BitOffs>
+            <BitOffs>650862448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xClose_B</Name>
@@ -35162,7 +35239,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450808</BitOffs>
+            <BitOffs>650862456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xClose_C</Name>
@@ -35174,7 +35251,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450816</BitOffs>
+            <BitOffs>650862464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xOPN_DO</Name>
@@ -35186,7 +35263,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450824</BitOffs>
+            <BitOffs>650862472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xTrigger</Name>
@@ -35199,7 +35276,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450904</BitOffs>
+            <BitOffs>650862552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xVFS_Open</Name>
@@ -35212,7 +35289,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450912</BitOffs>
+            <BitOffs>650862560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xVFS_Closed</Name>
@@ -35225,7 +35302,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450920</BitOffs>
+            <BitOffs>650862568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xVAC_FAULT_OK</Name>
@@ -35238,7 +35315,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450928</BitOffs>
+            <BitOffs>650862576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_xMPS_OK</Name>
@@ -35251,7 +35328,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450936</BitOffs>
+            <BitOffs>650862584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1.q_eVFS_State</Name>
@@ -35264,14 +35341,114 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665450944</BitOffs>
+            <BitOffs>650862592</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>FSV_task Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
+          <Symbol>
+            <Name>GVL_Logger.bTrickleTripped</Name>
+            <Comment> Global trickle trip flag</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
+		io: i
+		field: DESC Tripped by overall log count
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
+            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTripThreshold</Name>
+            <Comment> Minimum time between log messages</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
+            <Comment> Default trickle trip, activated by global threshold</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTripResetPeriod</Name>
+            <Comment> Default time for CB auto-reset</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>600000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nGlobAccEvents</Name>
+            <Comment> Global log message count</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogMessageCount
+		io: i
+		field: DESC Total log messages on the last cycle
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4179200</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
             <Comment> TwinCAT System Service </Comment>
@@ -36056,192 +36233,6 @@ for FAST shutter control</Comment>
             <BitOffs>4389664</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}">PlcAppSystemInfo</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650842560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_FSV_task</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650846656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskOid_FSV_task</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650846688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList.__FSV_task</Name>
-            <BitSize>704</BitSize>
-            <BaseType>_Implicit_Task_Info</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.dwVersion</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcContextName</Name>
-                <Value>FSV_task</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650846784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650894784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
-            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655390096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTripThreshold</Name>
-            <Comment> Minimum time between log messages</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655392800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
-            <Comment> Default trickle trip, activated by global threshold</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655392992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTripResetPeriod</Name>
-            <Comment> Default time for CB auto-reset</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>600000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655393376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.bTrickleTripped</Name>
-            <Comment> Global trickle trip flag</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
-		io: i
-		field: DESC Tripped by overall log count
-	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655402256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nGlobAccEvents</Name>
-            <Comment> Global log message count</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)LCLSGeneral:LogMessageCount
-		io: i
-		field: DESC Total log messages on the last cycle
-	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655402272</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_Variables.g_FastFaultOutput2</Name>
             <Comment>FFO for Fast Shutter Valves upstream of ST1L0_XTES</Comment>
             <BitSize>264896</BitSize>
@@ -36256,7 +36247,7 @@ for FAST shutter control</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-    pv: PLC:KFE:VAC:K0:FFO:02
+    pv: @(PREFIX)FFO:05
 </Value>
               </Property>
               <Property>
@@ -36267,7 +36258,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>664334976</BitOffs>
+            <BitOffs>642843200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VFS.fb_TV2K0_VFS_1</Name>
@@ -36311,14 +36302,100 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665339392</BitOffs>
+            <BitOffs>650751040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}">PlcAppSystemInfo</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650862912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_FSV_task</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650867008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_FSV_task</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650867040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList.__FSV_task</Name>
+            <BitSize>704</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcContextName</Name>
+                <Value>FSV_task</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650867136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650899520</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>FSV_task Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
             <Comment> Any time a FF occurs</Comment>
@@ -36343,7 +36420,24 @@ for FAST shutter control</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
+          <Symbol>
+            <Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
+            <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
+            <BitSize>48</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
+            <Properties>
+              <Property>
+                <Name>naming</Name>
+                <Value>omit</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>4096040</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>LCLS_Vacuum.Global_Variables.g_stSystem.I_EcatMaster1</Name>
             <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
@@ -36378,126 +36472,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634611888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.wFrmXWcState</Name>
-            <Comment> link to task related ethercat frame state (Frm1WcState)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^Inputs^Frm1WcState</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>649167328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCount</Name>
-            <Comment> link to SlaveCount of EtherCAT Master (Inputs)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^Inputs^SlaveCount</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>650250624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDevState</Name>
-            <Comment> link to DevState of EtherCAT Master (Inputs)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^Inputs^DevState</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>650250640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDeviceId</Name>
-            <Comment> link to DevID of EtherCAT Master (InfoData)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^InfoData^DevId</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>650250656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.arrEcMasterNetId</Name>
-            <Comment> link to NetID of EtherCAT Master (InfoData)</Comment>
-            <BitSize>48</BitSize>
-            <BaseType Namespace="Tc2_System">T_AmsNetIdArr</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^InfoData^AmsNetId</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>650250672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCountCfg</Name>
-            <Comment> link to CfgSlaveCount of EtherCAT Master (InfoData)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIID^Device 1 (EtherCAT)^InfoData^CfgSlaveCount</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>650250912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
-            <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
-            <BitSize>48</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
-            <Properties>
-              <Property>
-                <Name>naming</Name>
-                <Value>omit</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>656188200</BitOffs>
+            <BitOffs>634609008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.fbArbiterIO.i_stCurrentBP</Name>
@@ -36513,7 +36488,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656281696</BitOffs>
+            <BitOffs>634690080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.fbArbiterIO.xTxPDO_toggle</Name>
@@ -36534,7 +36509,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656285216</BitOffs>
+            <BitOffs>634693600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.fbArbiterIO.xTxPDO_state</Name>
@@ -36555,7 +36530,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656285217</BitOffs>
+            <BitOffs>634693601</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_GPI_1.i_iPRESS_R</Name>
@@ -36568,7 +36543,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656506080</BitOffs>
+            <BitOffs>634914976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GPI_1.i_iPRESS_R</Name>
@@ -36581,7 +36556,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656592800</BitOffs>
+            <BitOffs>635001696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GPI_1.i_iPRESS_R</Name>
@@ -36594,7 +36569,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656679520</BitOffs>
+            <BitOffs>635088416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GPI_1.i_iPRESS_R</Name>
@@ -36607,7 +36582,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656766240</BitOffs>
+            <BitOffs>635175136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GPI_2.i_iPRESS_R</Name>
@@ -36620,7 +36595,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656852960</BitOffs>
+            <BitOffs>635261856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_GPI_1.i_iPRESS_R</Name>
@@ -36633,7 +36608,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656939680</BitOffs>
+            <BitOffs>635348576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GPI_1.i_iPRESS_R</Name>
@@ -36646,7 +36621,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657026432</BitOffs>
+            <BitOffs>635435328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GPI_1.i_iPRESS_R</Name>
@@ -36659,7 +36634,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657113152</BitOffs>
+            <BitOffs>635522048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GPI_1.i_iPRESS_R</Name>
@@ -36672,7 +36647,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657199872</BitOffs>
+            <BitOffs>635608768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GPI_1.i_iPRESS_R</Name>
@@ -36685,7 +36660,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657286592</BitOffs>
+            <BitOffs>635695488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_GPI_1.i_iPRESS_R</Name>
@@ -36698,7 +36673,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657373312</BitOffs>
+            <BitOffs>635782208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GPI_1.i_iPRESS_R</Name>
@@ -36711,7 +36686,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657460032</BitOffs>
+            <BitOffs>635868928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_GCC_1.i_iPRESS_R</Name>
@@ -36724,7 +36699,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657548032</BitOffs>
+            <BitOffs>635956928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1.i_iPRESS_R</Name>
@@ -36737,7 +36712,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657636096</BitOffs>
+            <BitOffs>636044992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PCPM3B_GFS_1.i_iPRESS_R</Name>
@@ -36750,7 +36725,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657724160</BitOffs>
+            <BitOffs>636133056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GCC_1.i_iPRESS_R</Name>
@@ -36763,7 +36738,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657812224</BitOffs>
+            <BitOffs>636221120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GCC_1.i_iPRESS_R</Name>
@@ -36776,7 +36751,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657900288</BitOffs>
+            <BitOffs>636309184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GCC_2.i_iPRESS_R</Name>
@@ -36789,7 +36764,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657988352</BitOffs>
+            <BitOffs>636397248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_GCC_1.i_iPRESS_R</Name>
@@ -36802,7 +36777,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658076416</BitOffs>
+            <BitOffs>636485312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1.i_iPRESS_R</Name>
@@ -36815,7 +36790,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658164720</BitOffs>
+            <BitOffs>636573616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1.i_xHV_ON</Name>
@@ -36828,7 +36803,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658164744</BitOffs>
+            <BitOffs>636573640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1.i_xDisc_Active</Name>
@@ -36841,7 +36816,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658164752</BitOffs>
+            <BitOffs>636573648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1.i_iPRESS_R</Name>
@@ -36854,7 +36829,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658253104</BitOffs>
+            <BitOffs>636662000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1.i_xHV_ON</Name>
@@ -36867,7 +36842,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658253128</BitOffs>
+            <BitOffs>636662024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1.i_xDisc_Active</Name>
@@ -36880,7 +36855,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658253136</BitOffs>
+            <BitOffs>636662032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1.i_iPRESS_R</Name>
@@ -36893,7 +36868,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658341488</BitOffs>
+            <BitOffs>636750384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1.i_xHV_ON</Name>
@@ -36906,7 +36881,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658341512</BitOffs>
+            <BitOffs>636750408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1.i_xDisc_Active</Name>
@@ -36919,7 +36894,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658341520</BitOffs>
+            <BitOffs>636750416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1.i_iPRESS_R</Name>
@@ -36932,7 +36907,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658429872</BitOffs>
+            <BitOffs>636838768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1.i_xHV_ON</Name>
@@ -36945,7 +36920,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658429896</BitOffs>
+            <BitOffs>636838792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1.i_xDisc_Active</Name>
@@ -36958,7 +36933,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658429904</BitOffs>
+            <BitOffs>636838800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1.i_iPRESS_R</Name>
@@ -36971,7 +36946,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658518256</BitOffs>
+            <BitOffs>636927152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1.i_xHV_ON</Name>
@@ -36984,7 +36959,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658518280</BitOffs>
+            <BitOffs>636927176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1.i_xDisc_Active</Name>
@@ -36997,7 +36972,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658518288</BitOffs>
+            <BitOffs>636927184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1.i_iPRESS_R</Name>
@@ -37010,7 +36985,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658606640</BitOffs>
+            <BitOffs>637015536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1.i_xHV_ON</Name>
@@ -37023,7 +36998,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658606664</BitOffs>
+            <BitOffs>637015560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1.i_xDisc_Active</Name>
@@ -37036,7 +37011,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658606672</BitOffs>
+            <BitOffs>637015568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_VGC_1.i_xOpnLS</Name>
@@ -37049,7 +37024,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658784256</BitOffs>
+            <BitOffs>637193152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_VGC_1.i_xClsLS</Name>
@@ -37061,7 +37036,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658784264</BitOffs>
+            <BitOffs>637193160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM1K0_GMD_VGC_1.i_xOpnLS</Name>
@@ -37074,7 +37049,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658961600</BitOffs>
+            <BitOffs>637370496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM1K0_GMD_VGC_1.i_xClsLS</Name>
@@ -37086,7 +37061,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658961608</BitOffs>
+            <BitOffs>637370504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_AT1K0_GAS_VGC_1.i_xOpnLS</Name>
@@ -37099,7 +37074,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659138944</BitOffs>
+            <BitOffs>637547840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_AT1K0_GAS_VGC_1.i_xClsLS</Name>
@@ -37111,7 +37086,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659138952</BitOffs>
+            <BitOffs>637547848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_1.i_xOpnLS</Name>
@@ -37124,7 +37099,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659316288</BitOffs>
+            <BitOffs>637725184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_1.i_xClsLS</Name>
@@ -37136,7 +37111,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659316296</BitOffs>
+            <BitOffs>637725192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_2.i_xOpnLS</Name>
@@ -37149,7 +37124,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659493632</BitOffs>
+            <BitOffs>637902528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_2.i_xClsLS</Name>
@@ -37161,7 +37136,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659493640</BitOffs>
+            <BitOffs>637902536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VGC_1.i_xOpnLS</Name>
@@ -37174,7 +37149,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659670976</BitOffs>
+            <BitOffs>638079872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VGC_1.i_xClsLS</Name>
@@ -37186,7 +37161,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659670984</BitOffs>
+            <BitOffs>638079880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_VGC_1.i_xOpnLS</Name>
@@ -37199,7 +37174,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659848320</BitOffs>
+            <BitOffs>638257216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_VGC_1.i_xClsLS</Name>
@@ -37211,7 +37186,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659848328</BitOffs>
+            <BitOffs>638257224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_VGC_1.i_xOpnLS</Name>
@@ -37224,7 +37199,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660025664</BitOffs>
+            <BitOffs>638434560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_VGC_1.i_xClsLS</Name>
@@ -37236,7 +37211,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660025672</BitOffs>
+            <BitOffs>638434568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_1.i_xOpnLS</Name>
@@ -37249,7 +37224,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660203008</BitOffs>
+            <BitOffs>638611904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_1.i_xClsLS</Name>
@@ -37261,7 +37236,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660203016</BitOffs>
+            <BitOffs>638611912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_2.i_xOpnLS</Name>
@@ -37274,7 +37249,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660380352</BitOffs>
+            <BitOffs>638789248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_2.i_xClsLS</Name>
@@ -37286,7 +37261,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660380360</BitOffs>
+            <BitOffs>638789256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K3_PPM_VGC_1.i_xOpnLS</Name>
@@ -37299,7 +37274,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660557696</BitOffs>
+            <BitOffs>638966592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K3_PPM_VGC_1.i_xClsLS</Name>
@@ -37311,7 +37286,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660557704</BitOffs>
+            <BitOffs>638966600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_VGC_1.i_xOpnLS</Name>
@@ -37324,7 +37299,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660735040</BitOffs>
+            <BitOffs>639143936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_VGC_1.i_xClsLS</Name>
@@ -37336,7 +37311,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660735048</BitOffs>
+            <BitOffs>639143944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_VGC_1.i_xOpnLS</Name>
@@ -37349,7 +37324,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660912384</BitOffs>
+            <BitOffs>639321280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_VGC_1.i_xClsLS</Name>
@@ -37361,7 +37336,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660912392</BitOffs>
+            <BitOffs>639321288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1.i_xOpnLS</Name>
@@ -37374,7 +37349,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661089728</BitOffs>
+            <BitOffs>639498624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1.i_xClsLS</Name>
@@ -37386,7 +37361,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661089736</BitOffs>
+            <BitOffs>639498632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVAC_FAULT_OK</Name>
@@ -37399,7 +37374,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661178288</BitOffs>
+            <BitOffs>639587184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xTrigger</Name>
@@ -37412,7 +37387,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661179104</BitOffs>
+            <BitOffs>639588000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVFS_Open</Name>
@@ -37424,7 +37399,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661179112</BitOffs>
+            <BitOffs>639588008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xVFS_Closed</Name>
@@ -37436,7 +37411,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661179120</BitOffs>
+            <BitOffs>639588016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_xMPS_OK</Name>
@@ -37458,7 +37433,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661179128</BitOffs>
+            <BitOffs>639588024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.i_eVFS_State</Name>
@@ -37471,7 +37446,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661179136</BitOffs>
+            <BitOffs>639588032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_1.i_iPRESS</Name>
@@ -37483,7 +37458,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661265904</BitOffs>
+            <BitOffs>639674800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_1.i_xSP_DI</Name>
@@ -37496,7 +37471,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661265920</BitOffs>
+            <BitOffs>639674816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_2.i_iPRESS</Name>
@@ -37508,7 +37483,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661356528</BitOffs>
+            <BitOffs>639765424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_2.i_xSP_DI</Name>
@@ -37521,7 +37496,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661356544</BitOffs>
+            <BitOffs>639765440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_3.i_iPRESS</Name>
@@ -37533,7 +37508,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661447152</BitOffs>
+            <BitOffs>639856048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_3.i_xSP_DI</Name>
@@ -37546,7 +37521,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661447168</BitOffs>
+            <BitOffs>639856064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_4.i_iPRESS</Name>
@@ -37558,7 +37533,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661537776</BitOffs>
+            <BitOffs>639946672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_4.i_xSP_DI</Name>
@@ -37571,7 +37546,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661537792</BitOffs>
+            <BitOffs>639946688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_5.i_iPRESS</Name>
@@ -37583,7 +37558,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661628400</BitOffs>
+            <BitOffs>640037296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_5.i_xSP_DI</Name>
@@ -37596,7 +37571,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661628416</BitOffs>
+            <BitOffs>640037312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PCPM3B_PIP_1.i_iPRESS</Name>
@@ -37608,7 +37583,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661719024</BitOffs>
+            <BitOffs>640127920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PCPM3B_PIP_1.i_xSP_DI</Name>
@@ -37621,7 +37596,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661719040</BitOffs>
+            <BitOffs>640127936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_PIP_1.i_iPRESS</Name>
@@ -37633,7 +37608,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661809648</BitOffs>
+            <BitOffs>640218544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_PIP_1.i_xSP_DI</Name>
@@ -37646,7 +37621,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661809664</BitOffs>
+            <BitOffs>640218560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0.i_iPRESS</Name>
@@ -37658,7 +37633,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661900272</BitOffs>
+            <BitOffs>640309168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0.i_xSP_DI</Name>
@@ -37671,7 +37646,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661900288</BitOffs>
+            <BitOffs>640309184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_PIP_1.i_iPRESS</Name>
@@ -37683,7 +37658,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661990896</BitOffs>
+            <BitOffs>640399792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_PIP_1.i_xSP_DI</Name>
@@ -37696,7 +37671,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661990912</BitOffs>
+            <BitOffs>640399808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_PIP_1.i_iPRESS</Name>
@@ -37708,7 +37683,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662081520</BitOffs>
+            <BitOffs>640490416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_PIP_1.i_xSP_DI</Name>
@@ -37721,7 +37696,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662081536</BitOffs>
+            <BitOffs>640490432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_PIP_1.i_iPRESS</Name>
@@ -37733,7 +37708,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662172144</BitOffs>
+            <BitOffs>640581040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_PIP_1.i_xSP_DI</Name>
@@ -37746,7 +37721,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662172160</BitOffs>
+            <BitOffs>640581056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_1.i_iPRESS</Name>
@@ -37758,7 +37733,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662262768</BitOffs>
+            <BitOffs>640671664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_1.i_xSP_DI</Name>
@@ -37771,7 +37746,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662262784</BitOffs>
+            <BitOffs>640671680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_2.i_iPRESS</Name>
@@ -37783,7 +37758,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662353392</BitOffs>
+            <BitOffs>640762288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_2.i_xSP_DI</Name>
@@ -37796,7 +37771,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662353408</BitOffs>
+            <BitOffs>640762304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_PIP_1.i_iPRESS</Name>
@@ -37808,7 +37783,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662444016</BitOffs>
+            <BitOffs>640852912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_PIP_1.i_xSP_DI</Name>
@@ -37821,7 +37796,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662444032</BitOffs>
+            <BitOffs>640852928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_PIP_1.i_iPRESS</Name>
@@ -37833,7 +37808,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662534640</BitOffs>
+            <BitOffs>640943536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_PIP_1.i_xSP_DI</Name>
@@ -37846,7 +37821,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662534656</BitOffs>
+            <BitOffs>640943552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VAC_INTF.fb_TV1K0_INTF_GCC_1.i_xEXT_Press_OK</Name>
@@ -37859,7 +37834,7 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662539720</BitOffs>
+            <BitOffs>640948616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_VAC_INTF.fb_PC1K1_INTF_GCC_1.i_xEXT_Press_OK</Name>
@@ -37872,52 +37847,116 @@ for FAST shutter control</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662541032</BitOffs>
+            <BitOffs>640955240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.wFrmXWcState</Name>
+            <Comment> link to task related ethercat frame state (Frm1WcState)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^Inputs^Frm1WcState</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>649180512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCount</Name>
+            <Comment> link to SlaveCount of EtherCAT Master (Inputs)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^Inputs^SlaveCount</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>650263808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDevState</Name>
+            <Comment> link to DevState of EtherCAT Master (Inputs)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^Inputs^DevState</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>650263824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterDeviceId</Name>
+            <Comment> link to DevID of EtherCAT Master (InfoData)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^InfoData^DevId</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>650263840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.arrEcMasterNetId</Name>
+            <Comment> link to NetID of EtherCAT Master (InfoData)</Comment>
+            <BitSize>48</BitSize>
+            <BaseType Namespace="Tc2_System">T_AmsNetIdArr</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^InfoData^AmsNetId</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>650263856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper.nEcMasterSlaveCountCfg</Name>
+            <Comment> link to CfgSlaveCount of EtherCAT Master (InfoData)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIID^Device 1 (EtherCAT)^InfoData^CfgSlaveCount</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>650264096</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">17</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>83361792</ByteSize>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1.q_xTREATY_VGC_STATUS</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>641032384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper.q_xILK_OK_DO</Name>
-            <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>641033664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_TMO_ILK_Lower.q_xILK_OK_DO</Name>
-            <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>641034816</BitOffs>
-          </Symbol>
+          <ByteSize>82116608</ByteSize>
           <Symbol>
             <Name>PRG_PMPS.fbArbiterIO.q_stRequestedBP</Name>
             <BitSize>1760</BitSize>
@@ -37932,7 +37971,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656283456</BitOffs>
+            <BitOffs>634691840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_GCC_1.q_xHV_DIS</Name>
@@ -37948,7 +37987,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657548048</BitOffs>
+            <BitOffs>635956944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1.q_xHV_DIS</Name>
@@ -37964,7 +38003,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657636112</BitOffs>
+            <BitOffs>636045008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PCPM3B_GFS_1.q_xHV_DIS</Name>
@@ -37980,7 +38019,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657724176</BitOffs>
+            <BitOffs>636133072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GCC_1.q_xHV_DIS</Name>
@@ -37996,7 +38035,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657812240</BitOffs>
+            <BitOffs>636221136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GCC_1.q_xHV_DIS</Name>
@@ -38012,7 +38051,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657900304</BitOffs>
+            <BitOffs>636309200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_GCC_2.q_xHV_DIS</Name>
@@ -38028,7 +38067,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657988368</BitOffs>
+            <BitOffs>636397264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_GCC_1.q_xHV_DIS</Name>
@@ -38044,7 +38083,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658076432</BitOffs>
+            <BitOffs>636485328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1.q_xHV_DIS</Name>
@@ -38057,7 +38096,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658164736</BitOffs>
+            <BitOffs>636573632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1.q_xHV_DIS</Name>
@@ -38070,7 +38109,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658253120</BitOffs>
+            <BitOffs>636662016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1.q_xHV_DIS</Name>
@@ -38083,7 +38122,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658341504</BitOffs>
+            <BitOffs>636750400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1.q_xHV_DIS</Name>
@@ -38096,7 +38135,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658429888</BitOffs>
+            <BitOffs>636838784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1.q_xHV_DIS</Name>
@@ -38109,7 +38148,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658518272</BitOffs>
+            <BitOffs>636927168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1.q_xHV_DIS</Name>
@@ -38122,7 +38161,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658606656</BitOffs>
+            <BitOffs>637015552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_VGC_1.q_xOPN_DO</Name>
@@ -38134,7 +38173,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658784272</BitOffs>
+            <BitOffs>637193168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM1K0_GMD_VGC_1.q_xOPN_DO</Name>
@@ -38146,7 +38185,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658961616</BitOffs>
+            <BitOffs>637370512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_AT1K0_GAS_VGC_1.q_xOPN_DO</Name>
@@ -38158,7 +38197,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659138960</BitOffs>
+            <BitOffs>637547856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_1.q_xOPN_DO</Name>
@@ -38170,7 +38209,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659316304</BitOffs>
+            <BitOffs>637725200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_2.q_xOPN_DO</Name>
@@ -38182,7 +38221,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659493648</BitOffs>
+            <BitOffs>637902544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VGC_1.q_xOPN_DO</Name>
@@ -38194,7 +38233,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659670992</BitOffs>
+            <BitOffs>638079888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_VGC_1.q_xOPN_DO</Name>
@@ -38206,7 +38245,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659848336</BitOffs>
+            <BitOffs>638257232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_VGC_1.q_xOPN_DO</Name>
@@ -38218,7 +38257,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660025680</BitOffs>
+            <BitOffs>638434576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_1.q_xOPN_DO</Name>
@@ -38230,7 +38269,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660203024</BitOffs>
+            <BitOffs>638611920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_2.q_xOPN_DO</Name>
@@ -38242,7 +38281,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660380368</BitOffs>
+            <BitOffs>638789264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K3_PPM_VGC_1.q_xOPN_DO</Name>
@@ -38254,7 +38293,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660557712</BitOffs>
+            <BitOffs>638966608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_VGC_1.q_xOPN_DO</Name>
@@ -38266,7 +38305,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660735056</BitOffs>
+            <BitOffs>639143952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_VGC_1.q_xOPN_DO</Name>
@@ -38278,7 +38317,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660912400</BitOffs>
+            <BitOffs>639321296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1.q_xOPN_DO</Name>
@@ -38290,7 +38329,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661089744</BitOffs>
+            <BitOffs>639498640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.iq_stValve.xCLS_SW</Name>
@@ -38312,7 +38351,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661176968</BitOffs>
+            <BitOffs>639585864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xPRESS_OK</Name>
@@ -38325,7 +38364,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179040</BitOffs>
+            <BitOffs>639587936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOPN_SW</Name>
@@ -38337,7 +38376,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179048</BitOffs>
+            <BitOffs>639587944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xCLS_SW</Name>
@@ -38350,7 +38389,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179056</BitOffs>
+            <BitOffs>639587952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xVAC_FAULT_Reset</Name>
@@ -38363,7 +38402,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179064</BitOffs>
+            <BitOffs>639587960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOverrideMode</Name>
@@ -38376,7 +38415,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179072</BitOffs>
+            <BitOffs>639587968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xOverrideOpen</Name>
@@ -38388,7 +38427,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179080</BitOffs>
+            <BitOffs>639587976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xVetoValveOpenDO</Name>
@@ -38401,7 +38440,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179088</BitOffs>
+            <BitOffs>639587984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface.q_xVetoValveClosed</Name>
@@ -38413,7 +38452,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661179096</BitOffs>
+            <BitOffs>639587992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_1.q_xHVEna_DO</Name>
@@ -38426,7 +38465,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661265888</BitOffs>
+            <BitOffs>639674784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_2.q_xHVEna_DO</Name>
@@ -38439,7 +38478,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661356512</BitOffs>
+            <BitOffs>639765408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_3.q_xHVEna_DO</Name>
@@ -38452,7 +38491,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661447136</BitOffs>
+            <BitOffs>639856032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_4.q_xHVEna_DO</Name>
@@ -38465,7 +38504,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661537760</BitOffs>
+            <BitOffs>639946656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_5.q_xHVEna_DO</Name>
@@ -38478,7 +38517,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661628384</BitOffs>
+            <BitOffs>640037280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PCPM3B_PIP_1.q_xHVEna_DO</Name>
@@ -38491,7 +38530,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661719008</BitOffs>
+            <BitOffs>640127904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0_PIP_1.q_xHVEna_DO</Name>
@@ -38504,7 +38543,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661809632</BitOffs>
+            <BitOffs>640218528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_PA1K0.q_xHVEna_DO</Name>
@@ -38517,7 +38556,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661900256</BitOffs>
+            <BitOffs>640309152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K1_BEND_PIP_1.q_xHVEna_DO</Name>
@@ -38530,7 +38569,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661990880</BitOffs>
+            <BitOffs>640399776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR1K3_TXI_PIP_1.q_xHVEna_DO</Name>
@@ -38543,7 +38582,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662081504</BitOffs>
+            <BitOffs>640490400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_MR2K3_TXI_PIP_1.q_xHVEna_DO</Name>
@@ -38556,7 +38595,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662172128</BitOffs>
+            <BitOffs>640581024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_1.q_xHVEna_DO</Name>
@@ -38569,7 +38608,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662262752</BitOffs>
+            <BitOffs>640671648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_2.q_xHVEna_DO</Name>
@@ -38582,7 +38621,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662353376</BitOffs>
+            <BitOffs>640762272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_TV3K0_PIP_1.q_xHVEna_DO</Name>
@@ -38595,7 +38634,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662444000</BitOffs>
+            <BitOffs>640852896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SXR_VAC.fb_SL1K0_PIP_1.q_xHVEna_DO</Name>
@@ -38608,7 +38647,45 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662534624</BitOffs>
+            <BitOffs>640943520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1.q_xTREATY_VGC_STATUS</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>640951616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper.q_xILK_OK_DO</Name>
+            <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>640952896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_TMO_ILK_Lower.q_xILK_OK_DO</Name>
+            <Comment> Send the signal to indicate that the interlock pressure has been met.</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>640954048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputK0.q_xFastFaultOut</Name>
@@ -38628,7 +38705,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663010760</BitOffs>
+            <BitOffs>641518984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputK2.q_xFastFaultOut</Name>
@@ -38648,7 +38725,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663275656</BitOffs>
+            <BitOffs>641783880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputK3.q_xFastFaultOut</Name>
@@ -38668,7 +38745,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663540552</BitOffs>
+            <BitOffs>642048776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputK4.q_xFastFaultOut</Name>
@@ -38688,7 +38765,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663805448</BitOffs>
+            <BitOffs>642313672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputAll.q_xFastFaultOut</Name>
@@ -38708,7 +38785,7 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664070344</BitOffs>
+            <BitOffs>642578568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.g_FastFaultOutputINTF.q_xFastFaultOut</Name>
@@ -38728,14 +38805,104 @@ for FAST shutter control</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664600136</BitOffs>
+            <BitOffs>643108360</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
+          <Symbol>
+            <Name>DefaultGlobals.stSys</Name>
+            <Comment>Included for you</Comment>
+            <BitSize>88</BitSize>
+            <BaseType Namespace="LCLS_General">ST_System</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.iLogPort</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>54321</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogPort
+		io: io
+		field: DESC The log host UDP port
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>DefaultGlobals.fTimeStamp</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.cLogHost</Name>
+            <Comment>
+	Using the IP address directly avoids DNS configuration issues.
+	While we may want to address this in the future, for now the static IP
+	will suffice:
+
+	$ nslookup ctl-logsrv01
+	Name:   ctl-logsrv01.pcdsn
+	Address: 172.21.32.36
+	</Comment>
+            <BitSize>128</BitSize>
+            <BaseType>STRING(15)</BaseType>
+            <Default>
+              <String>172.21.32.36</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogHost
+		io: io
+		field: DESC The log host IP address
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sIpTidbit</Name>
+            <BitSize>56</BitSize>
+            <BaseType>STRING(6)</BaseType>
+            <Default>
+              <String>172.21</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096320</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>Global_Variables.EC_CMD_TYPE_APRD</Name>
             <Comment>ethercat commands</Comment>
@@ -38752,6 +38919,35 @@ for FAST shutter control</Comment>
             <BitOffs>4096376</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>GVL_Logger.nTrickleTripTime</Name>
+            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sPlcHostname</Name>
+            <BitSize>648</BitSize>
+            <BaseType>STRING(80)</BaseType>
+            <Default>
+              <String>unknown</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096512</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Global_Variables.EC_CMD_TYPE_APWR</Name>
             <BitSize>8</BitSize>
             <BaseType>BYTE</BaseType>
@@ -38764,6 +38960,80 @@ for FAST shutter control</Comment>
               </Property>
             </Properties>
             <BitOffs>4097160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables_EtherCAT.iSLAVEADDR_ARR_SIZE</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>256</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
+		TODO: Activate the "Replace constants" option in the
+		TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window. 
+	</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.fbRootLogger</Name>
+            <Comment>Instantiated here to be used everywhere</Comment>
+            <BitSize>81984</BitSize>
+            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleThreshold</Name>
+            <Comment> If GlobAccEvents goes over this level for longer than the </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4179232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables_EtherCAT.ESC_MAX_PORTS</Name>
+            <Comment> Maximum number of ports (4) on ESC</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4179264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EC_AMSPORT_MASTER</Name>
@@ -44740,6 +45010,24 @@ for FAST shutter control</Comment>
             <BitOffs>626223792</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>GVL_Variables.xSystemOverrideMode</Name>
+            <Comment> Global system override for the prototype section</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)SYSOVERRIDE
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>626223800</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
             <Comment> Pointer to current test suite being called </Comment>
             <BitSize>32</BitSize>
@@ -44928,15 +45216,20 @@ for FAST shutter control</Comment>
             <BitOffs>634595104</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Variables.xSystemOverrideMode</Name>
-            <Comment> Global system override for the prototype section</Comment>
+            <Name>GVL_Variables.xReset_PMPS_FFO_K0</Name>
+            <Comment> *****************
+ Fast fault resets
+ *****************</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-    pv: @(PREFIX)SYSOVERRIDE
+pv: @(PREFIX)RESET:FF1
 </Value>
               </Property>
               <Property>
@@ -44983,7 +45276,8 @@ for FAST shutter control</Comment>
             <BitOffs>634596384</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
@@ -45008,6 +45302,46 @@ for FAST shutter control</Comment>
             <BitOffs>634596416</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PMPS_GVL.stRequestedBeamParameters</Name>
+            <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)RequestedBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634597440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stCurrentBeamParameters</Name>
+            <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)CurrentBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634599200</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
             <BitSize>1024</BitSize>
             <BaseType>REAL</BaseType>
@@ -45030,7 +45364,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634600832</BitOffs>
+            <BitOffs>634600960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -45042,7 +45376,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634601856</BitOffs>
+            <BitOffs>634601984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -45057,7 +45391,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634601888</BitOffs>
+            <BitOffs>634602016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -45071,7 +45405,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634601920</BitOffs>
+            <BitOffs>634602048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -45085,7 +45419,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634601984</BitOffs>
+            <BitOffs>634602112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -45099,7 +45433,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634602048</BitOffs>
+            <BitOffs>634602176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -45114,7 +45448,21 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634602080</BitOffs>
+            <BitOffs>634602208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634602240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -45139,22 +45487,68 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607200</BitOffs>
+            <BitOffs>634602256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
             <Default>
-              <Value>16</Value>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607216</BitOffs>
+            <BitOffs>634602272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634602336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634604096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -45169,7 +45563,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607232</BitOffs>
+            <BitOffs>634605856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -45183,7 +45577,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607248</BitOffs>
+            <BitOffs>634605872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -45202,7 +45596,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607264</BitOffs>
+            <BitOffs>634605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -45229,7 +45623,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634608288</BitOffs>
+            <BitOffs>634606912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -45384,7 +45778,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634608320</BitOffs>
+            <BitOffs>634606944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -45539,7 +45933,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634609344</BitOffs>
+            <BitOffs>634607968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -45554,7 +45948,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610368</BitOffs>
+            <BitOffs>634608992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -45569,7 +45963,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610400</BitOffs>
+            <BitOffs>634609024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -45584,7 +45978,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610432</BitOffs>
+            <BitOffs>634609056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -45595,70 +45989,7 @@ for FAST shutter control</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.xReset_PMPS_FFO_K0</Name>
-            <Comment> *****************
- Fast fault resets
- *****************</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-pv: @(PREFIX)RESET:FF1
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634610808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.xReset_PMPS_FFO_K2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-pv: @(PREFIX)RESET:FF2
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634611080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.xReset_PMPS_FFO_K3</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-pv: @(PREFIX)RESET:FF3
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634611880</BitOffs>
+            <BitOffs>634609088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -45698,7 +46029,7 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634693984</BitOffs>
+            <BitOffs>634609344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -45709,7 +46040,7 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634694272</BitOffs>
+            <BitOffs>634609632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -45723,7 +46054,7 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634701248</BitOffs>
+            <BitOffs>634616640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -45737,7 +46068,7 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634701312</BitOffs>
+            <BitOffs>634616704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -45773,7 +46104,7 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634701376</BitOffs>
+            <BitOffs>634616768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_DataExchange</Name>
@@ -45813,13 +46144,13 @@ pv: @(PREFIX)RESET:FF3
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634701664</BitOffs>
+            <BitOffs>634617056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MAIN.fbGetCurTaskIdx</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>634751328</BitOffs>
+            <BitOffs>634666816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MAIN.fbWritePersistentData</Name>
@@ -45830,7 +46161,7 @@ pv: @(PREFIX)RESET:FF3
  For Persistent Data</Comment>
             <BitSize>1600</BitSize>
             <BaseType Namespace="Tc2_Utilities">WritePersistentData</BaseType>
-            <BitOffs>634751456</BitOffs>
+            <BitOffs>634666944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.fbTime</Name>
@@ -45846,7 +46177,7 @@ pv: @(PREFIX)RESET:FF3
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>634753216</BitOffs>
+            <BitOffs>634668704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.logTimer</Name>
@@ -45862,13 +46193,13 @@ pv: @(PREFIX)RESET:FF3
                 <Value>1000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634772256</BitOffs>
+            <BitOffs>634687744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.plcName</Name>
             <BitSize>128</BitSize>
             <BaseType>STRING(15)</BaseType>
-            <BitOffs>634772480</BitOffs>
+            <BitOffs>634687968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.plcHeartbeat</Name>
@@ -45883,7 +46214,7 @@ pv: @(PREFIX)RESET:FF3
                 <Value> pv: plcHeartbeat </Value>
               </Property>
             </Properties>
-            <BitOffs>634772608</BitOffs>
+            <BitOffs>634688096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.plcInfo</Name>
@@ -45895,7 +46226,7 @@ pv: @(PREFIX)RESET:FF3
                 <Value> pv: plcInfo </Value>
               </Property>
             </Properties>
-            <BitOffs>634772640</BitOffs>
+            <BitOffs>634688128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DIAGNOSTIC.plcLocalTime</Name>
@@ -45907,7 +46238,1099 @@ pv: @(PREFIX)RESET:FF3
                 <Value> pv: plcLocalTime </Value>
               </Property>
             </Properties>
-            <BitOffs>634772968</BitOffs>
+            <BitOffs>634688456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.xReset_PMPS_FFO_K2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+pv: @(PREFIX)RESET:FF2
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634688664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PMPS.fbArbiterIO</Name>
+            <BitSize>138752</BitSize>
+            <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
+            <BitOffs>634689280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_GPI_1</Name>
+            <Comment> FB_MKS317</Comment>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634828544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: IM1K0:XTES:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634915264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SL1K0:POWER:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635001984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV2K0:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635088704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_GPI_2</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV2K0:GPI:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635175424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PA1K0_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PA1K0:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635262144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GPI_1</Name>
+            <Comment> MKS275 Gauges</Comment>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K1:BEND:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635348864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K3:TXI:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635435584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR2K3:TXI:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635522304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635609024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV3K0_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV3K0:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635695744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GPI_1</Name>
+            <BitSize>86720</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K4:SOMS:GPI:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635782464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_GCC_1</Name>
+            <Comment> FB_MKS422</Comment>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635869184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: IM1K0:XTES:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635957248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PCPM3B_GFS_1</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PCPM3B:GFS:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636045312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GCC_1</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SL1K0:POWER:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636133376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_GCC_1</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV2K0:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636221440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_GCC_2</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV2K0:GCC:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636309504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PA1K0_GCC_1</Name>
+            <BitSize>88064</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PA1K0:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636397568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1</Name>
+            <Comment> MKS500_EP Gauges</Comment>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K1:BEND:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636485632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1</Name>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K3:TXI:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636574016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1</Name>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR2K3:TXI:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636662400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1</Name>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636750784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1</Name>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV3K0:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636839168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1</Name>
+            <BitSize>88384</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K4:SOMS:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636927552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_VGC_1</Name>
+            <Comment> VGC Valves</Comment>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637015936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_EM1K0_GMD_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: EM1K0:GMD:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637193280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_AT1K0_GAS_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: AT1K0:GAS:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637370624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: EM2K0:XGMD:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637547968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_2</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: EM2K0:XGMD:VGC:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637725312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV2K0:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>637902656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K1:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638080000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K3:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638257344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638434688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_2</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:VGC:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638612032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_IM1K3_PPM_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: IM1K3:PPM:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638789376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV3K0_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV3K0:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>638966720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_VGC_1</Name>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K4:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639144064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1</Name>
+            <Comment>linking pragma needed</Comment>
+            <BitSize>177344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: IM1K0:XTES:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.i_xOpnLS	:=	TIIB[=+-EL1004_03_04]^Channel 3^Input;
+                            .i_xClsLS	:=	TIIB[=+-EL1004_03_04]^Channel 4^Input;
+                            .q_xOPN_DO	:=	TIIB[=+-ES2004_03_03]^Channel 3^Output;
+                            .q_xOPN_DO	:=	TIIB[=+-ES2004_03_03]^Channel 4^Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639321408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface</Name>
+            <Comment> VFS valves</Comment>
+            <BitSize>89344</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_VFS_Interface</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.q_xPress_OK		:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xPress_OK;
+                             .q_xOPN_SW			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOPN_SW;
+                             .q_xCLS_SW			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xCLS_SW;
+                             .q_xVAC_FAULT_Reset:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xVAC_FAULT_Reset;
+                             .q_xOverrideMode	:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOverrideMode;
+                             .q_xOverrideOpen	:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOverrideOpen;
+                             .i_xTrigger		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xTrigger;
+                             .i_xVFS_Open		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVFS_Open;
+                             .i_xVFS_Closed		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVFS_Closed;
+                             .i_xVAC_FAULT_OK	:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVAC_FAULT_OK;
+                             .i_xMPS_OK			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xMPS_OK;
+                             .i_eVFS_State		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_eVFS_State
+</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: TV2K0:VFS:1
+    io: io
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639498752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_1</Name>
+            <Comment> PIP_Gamma Pumps</Comment>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639588096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_2</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:PIP:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639678720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_3</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:PIP:3 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639769344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_4</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:PIP:4 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639859968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_5</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:PIP:5 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639950592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PCPM3B_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PCPM3B:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640041216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PA1K0_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PA1K0:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640131840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_PA1K0</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PA1K0 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640222464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K1:BEND:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640313088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K3:TXI:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640403712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR2K3:TXI:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640494336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640584960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_2</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: SP1K1:MONO:PIP:2 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640675584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_TV3K0_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV3K0:PIP:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640766208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_SXR_VAC.fb_SL1K0_PIP_1</Name>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.i_iPRESS		:=	TIIB[=+-EL3064_02_07]^AI Standard Channel 1^Value;
+                                 .i_xSP_DI		:= 	TIIB[=+-EL1004_02_09]^Channel 1^Input;
+                                 .q_xHVEna_DO	:= 	TIIB[=+-EL2794_02_08]^Channel 1^Output
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: SL1K0:POWER:PIP:01	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640856832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_TV1K0_INTF_GCC_1</Name>
+            <Comment> AD Interface</Comment>
+            <BitSize>1184</BitSize>
+            <BaseType>FB_EXT_TREATY_GAUGE</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: TV1K0:INTF:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640947456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1</Name>
+            <BitSize>3008</BitSize>
+            <BaseType>FB_EXT_TREATY_VGC</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: RTDSK0:INTF:VGC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640948640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.st_TMO_ILK_Upper</Name>
+            <Comment> TMO vacuum interface</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ST_EXT_ILK</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K4:SOMS:GCC:1:ILK_UPPER</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640951648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.st_TMO_ILK_Lower</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ST_EXT_ILK</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: MR1K4:SOMS:GCC:1:ILK_LOWER</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640951712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper</Name>
+            <BitSize>1152</BitSize>
+            <BaseType>FB_EXT_ILK</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640951776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_TMO_ILK_Lower</Name>
+            <BitSize>1152</BitSize>
+            <BaseType>FB_EXT_ILK</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640952928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_PC1K1_INTF_GCC_1</Name>
+            <Comment> AD Interface</Comment>
+            <BitSize>1184</BitSize>
+            <BaseType>FB_EXT_TREATY_GAUGE</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value> pv: PC1K1:INTF:GCC:1 </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640954080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.n_EM1K0_VAC_counter</Name>
+            <Comment> EM1K0-GMD Vacuum Interface</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640955264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.n_AT1K0_VAC_counter</Name>
+            <Comment> AT1K0-GAS Vacuum Interface</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640955296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_EM1K0_GMD_GCC_10_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>640955328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_EM1K0_GMD_GCC_70_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641049216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_AT1K0_GAS_GCC_10_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641143104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_AT1K0_GAS_GCC_140_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641236992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.n_EM2K0_VAC_counter</Name>
+            <Comment> EM2K0-XGMD Vacuum Interface</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641330880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.xReset_PMPS_FFO_K3</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+pv: @(PREFIX)RESET:FF3
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641330912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Variables.xReset_PMPS_FFO_K4</Name>
@@ -45927,130 +47350,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634773176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.n_EM1K0_VAC_counter</Name>
-            <Comment> EM1K0-GMD Vacuum Interface</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634773792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_EM1K0_GMD_GCC_70_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634773824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_RTDSK0_INTF_VGC_1</Name>
-            <BitSize>3008</BitSize>
-            <BaseType>FB_EXT_TREATY_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:INTF:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>641029408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_TMO_ILK_Uppper</Name>
-            <BitSize>1152</BitSize>
-            <BaseType>FB_EXT_ILK</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>641032544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_TMO_ILK_Lower</Name>
-            <BitSize>1152</BitSize>
-            <BaseType>FB_EXT_ILK</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>641033696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.n_AT1K0_VAC_counter</Name>
-            <Comment> AT1K0-GAS Vacuum Interface</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>641129920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.n_EM2K0_VAC_counter</Name>
-            <Comment> EM2K0-XGMD Vacuum Interface</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>641129952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFault</Name>
-            <Comment> ************
- FB_FastFault
- ************</Comment>
-            <BitSize>25088</BitSize>
-            <BaseType Namespace="PMPS">FB_FastFault</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>643359808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbLogHandler</Name>
-            <Comment> *******
- Logging
- *******</Comment>
-            <BitSize>5782016</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>643384896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.fbEcatDiagWrapper</Name>
-            <BitSize>1096320</BitSize>
-            <BaseType Namespace="LCLS_General">FB_EcatDiagWrapper</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>649166912</BitOffs>
+            <BitOffs>641330920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -46065,7 +47365,236 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842312</BitOffs>
+            <BitOffs>641330936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_EM2K0_XGMD_GCC_10_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641330944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_VAC_INTF.fb_EM2K0_XGMD_GCC_90_reader</Name>
+            <BitSize>93888</BitSize>
+            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641424832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputK0</Name>
+            <Comment> ***************************
+ Hardware Fast fault outputs
+ ***************************
+ K0/SXR upstream specific faults</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)FFO:01
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641518720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputK2</Name>
+            <Comment> K2/RIX specific faults</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)FFO:02
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641783616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputK3</Name>
+            <Comment> K3/TXI specific faults</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)FFO:03
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>642048512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputK4</Name>
+            <Comment> K4/TMO specific faults</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)FFO:04
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>642313408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputAll</Name>
+            <Comment> Fault aggregator for combined beamline</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO (EL2202)]^Channel 1^Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>642578304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFaultOutputINTF</Name>
+            <Comment> Dummy FFO for valves not yet allowed to open. To be removed when proper interfaces to TXI and RIX vacuum are implemented.</Comment>
+            <BitSize>264896</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.i_sNetID</Name>
+                <String>172.21.92.73.1.1</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: @(PREFIX)FF1A
+</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>643108096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_FastFault</Name>
+            <Comment> ************
+ FB_FastFault
+ ************</Comment>
+            <BitSize>25088</BitSize>
+            <BaseType Namespace="PMPS">FB_FastFault</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>643372992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbLogHandler</Name>
+            <Comment> *******
+ Logging
+ *******</Comment>
+            <BitSize>5782016</BitSize>
+            <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>643398080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.fbEcatDiagWrapper</Name>
+            <BitSize>1096320</BitSize>
+            <BaseType Namespace="LCLS_General">FB_EcatDiagWrapper</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>649180096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Variables.g_fbArbiter1</Name>
+            <Comment> *******
+ Arbiter
+ *******</Comment>
+            <BitSize>474624</BitSize>
+            <BaseType Namespace="PMPS">FB_Arbiter</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+     pv: @(PREFIX)Arb:01
+</Value>
+              </Property>
+              <Property>
+                <Name>old_input_assignments</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>650276416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -46095,7 +47624,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842320</BitOffs>
+            <BitOffs>650862656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -46125,7 +47654,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842384</BitOffs>
+            <BitOffs>650862720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -46140,7 +47669,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842448</BitOffs>
+            <BitOffs>650862784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -46154,7 +47683,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842456</BitOffs>
+            <BitOffs>650862792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -46169,7 +47698,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842464</BitOffs>
+            <BitOffs>650862800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -46184,7 +47713,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842480</BitOffs>
+            <BitOffs>650862816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -46198,7 +47727,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842496</BitOffs>
+            <BitOffs>650862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -46212,7 +47741,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650842528</BitOffs>
+            <BitOffs>650862880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -46230,7 +47759,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650844608</BitOffs>
+            <BitOffs>650864960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -46244,7 +47773,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650846720</BitOffs>
+            <BitOffs>650867072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -46258,7 +47787,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650846752</BitOffs>
+            <BitOffs>650867104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -46279,7 +47808,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650847488</BitOffs>
+            <BitOffs>650867840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -46348,7 +47877,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650863680</BitOffs>
+            <BitOffs>650913152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -46417,7 +47946,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650863808</BitOffs>
+            <BitOffs>650913280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -46486,7 +48015,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650863936</BitOffs>
+            <BitOffs>650913408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -46555,7 +48084,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650864064</BitOffs>
+            <BitOffs>650913536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -46624,7 +48153,7 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650864192</BitOffs>
+            <BitOffs>650913664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -46693,1466 +48222,14 @@ pv: @(PREFIX)RESET:FF4
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650864320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.iLogPort</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>54321</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)LCLSGeneral:LogPort
-		io: io
-		field: DESC The log host UDP port
-	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>650933296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleTripTime</Name>
-            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655393184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
-            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
-		TODO: Activate the "Replace constants" option in the
-		TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window. 
-	</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655393568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleThreshold</Name>
-            <Comment> If GlobAccEvents goes over this level for longer than the </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655402720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables_EtherCAT.iSLAVEADDR_ARR_SIZE</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>256</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655403168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables_EtherCAT.ESC_MAX_PORTS</Name>
-            <Comment> Maximum number of ports (4) on ESC</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655403184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>DefaultGlobals.stSys</Name>
-            <Comment>Included for you</Comment>
-            <BitSize>88</BitSize>
-            <BaseType Namespace="LCLS_General">ST_System</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656188160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>DefaultGlobals.fTimeStamp</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656188288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.cLogHost</Name>
-            <Comment>
-	Using the IP address directly avoids DNS configuration issues.
-	While we may want to address this in the future, for now the static IP
-	will suffice:
-
-	$ nslookup ctl-logsrv01
-	Name:   ctl-logsrv01.pcdsn
-	Address: 172.21.32.36
-	</Comment>
-            <BitSize>128</BitSize>
-            <BaseType>STRING(15)</BaseType>
-            <Default>
-              <String>172.21.32.36</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)LCLSGeneral:LogHost
-		io: io
-		field: DESC The log host IP address
-	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656188352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sIpTidbit</Name>
-            <BitSize>56</BitSize>
-            <BaseType>STRING(6)</BaseType>
-            <Default>
-              <String>172.21</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656188480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sPlcHostname</Name>
-            <BitSize>648</BitSize>
-            <BaseType>STRING(80)</BaseType>
-            <Default>
-              <String>unknown</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656188536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.fbRootLogger</Name>
-            <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>81984</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656189184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stRequestedBeamParameters</Name>
-            <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)RequestedBP
-		io: i
-        archive: 1Hz monitor
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656271168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stCurrentBeamParameters</Name>
-            <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)CurrentBP
-		io: i
-        archive: 1Hz monitor
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656272928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656274688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656274752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656276512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_PMPS.fbArbiterIO</Name>
-            <BitSize>138752</BitSize>
-            <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>656280896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_GPI_1</Name>
-            <Comment> FB_MKS317</Comment>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656419648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: IM1K0:XTES:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656506368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SL1K0:POWER:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656593088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV2K0:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656679808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_GPI_2</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV2K0:GPI:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656766528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PA1K0_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS317</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PA1K0:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656853248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GPI_1</Name>
-            <Comment> MKS275 Gauges</Comment>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K1:BEND:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>656939968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K3:TXI:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657026688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR2K3:TXI:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657113408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657200128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV3K0_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV3K0:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657286848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GPI_1</Name>
-            <BitSize>86720</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS275</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K4:SOMS:GPI:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657373568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_GCC_1</Name>
-            <Comment> FB_MKS422</Comment>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657460288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_GCC_1</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: IM1K0:XTES:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657548352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PCPM3B_GFS_1</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PCPM3B:GFS:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657636416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SL1K0_POWER_GCC_1</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SL1K0:POWER:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657724480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_GCC_1</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV2K0:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657812544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_GCC_2</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV2K0:GCC:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657900608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PA1K0_GCC_1</Name>
-            <BitSize>88064</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS422</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PA1K0:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657988672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_GCC_1</Name>
-            <Comment> MKS500_EP Gauges</Comment>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K1:BEND:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658076736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_GCC_1</Name>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K3:TXI:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658165120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_GCC_1</Name>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR2K3:TXI:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658253504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_GCC_1</Name>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658341888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV3K0_GCC_1</Name>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV3K0:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658430272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_GCC_1</Name>
-            <BitSize>88384</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_MKS500</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K4:SOMS:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658518656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_VGC_1</Name>
-            <Comment> VGC Valves</Comment>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658607040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_EM1K0_GMD_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: EM1K0:GMD:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658784384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_AT1K0_GAS_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: AT1K0:GAS:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>658961728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: EM2K0:XGMD:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>659139072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_EM2K0_XGMD_VGC_2</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: EM2K0:XGMD:VGC:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>659316416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV2K0:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>659493760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K1:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>659671104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K3:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>659848448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660025792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_VGC_2</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:VGC:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660203136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_IM1K3_PPM_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: IM1K3:PPM:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660380480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV3K0_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV3K0:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660557824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K4_SOMS_VGC_1</Name>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K4:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660735168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_IM1K0_XTES_VGC_1</Name>
-            <Comment>linking pragma needed</Comment>
-            <BitSize>177344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VGC</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: IM1K0:XTES:VGC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.i_xOpnLS	:=	TIIB[=+-EL1004_03_04]^Channel 3^Input;
-                            .i_xClsLS	:=	TIIB[=+-EL1004_03_04]^Channel 4^Input;
-                            .q_xOPN_DO	:=	TIIB[=+-ES2004_03_03]^Channel 3^Output;
-                            .q_xOPN_DO	:=	TIIB[=+-ES2004_03_03]^Channel 4^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>660912512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV2K0_VFS_1_Interface</Name>
-            <Comment> VFS valves</Comment>
-            <BitSize>89344</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_VFS_Interface</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xPress_OK		:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xPress_OK;
-                             .q_xOPN_SW			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOPN_SW;
-                             .q_xCLS_SW			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xCLS_SW;
-                             .q_xVAC_FAULT_Reset:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xVAC_FAULT_Reset;
-                             .q_xOverrideMode	:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOverrideMode;
-                             .q_xOverrideOpen	:= 	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Inputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.i_xOverrideOpen;
-                             .i_xTrigger		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xTrigger;
-                             .i_xVFS_Open		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVFS_Open;
-                             .i_xVFS_Closed		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVFS_Closed;
-                             .i_xVAC_FAULT_OK	:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xVAC_FAULT_OK;
-                             .i_xMPS_OK			:=  TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_xMPS_OK;
-                             .i_eVFS_State		:=	TIPC^plc_kfe_vac_fs^plc_kfe_vac_fs Instance^PlcTask Outputs^GVL_SXR_VAC_FS_DEVICES.fb_TV2K0_VFS_1.q_eVFS_State
-</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: TV2K0:VFS:1
-    io: io
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661089856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_1</Name>
-            <Comment> PIP_Gamma Pumps</Comment>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661179200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_2</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:PIP:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661269824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_3</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:PIP:3 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661360448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_4</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:PIP:4 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661451072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_RTDSK0_PIP_5</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: RTDSK0:PIP:5 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661541696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PCPM3B_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PCPM3B:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661632320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PA1K0_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PA1K0:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661722944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_PA1K0</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PA1K0 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661813568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K1_BEND_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K1:BEND:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661904192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR1K3_TXI_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K3:TXI:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>661994816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_MR2K3_TXI_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR2K3:TXI:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662085440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662176064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SP1K1_MONO_PIP_2</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: SP1K1:MONO:PIP:2 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662266688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_TV3K0_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV3K0:PIP:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662357312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_SXR_VAC.fb_SL1K0_PIP_1</Name>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_PIP_Gamma</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.i_iPRESS		:=	TIIB[=+-EL3064_02_07]^AI Standard Channel 1^Value;
-                                 .i_xSP_DI		:= 	TIIB[=+-EL1004_02_09]^Channel 1^Input;
-                                 .q_xHVEna_DO	:= 	TIIB[=+-EL2794_02_08]^Channel 1^Output
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: SL1K0:POWER:PIP:01	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662447936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_TV1K0_INTF_GCC_1</Name>
-            <Comment> AD Interface</Comment>
-            <BitSize>1184</BitSize>
-            <BaseType>FB_EXT_TREATY_GAUGE</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: TV1K0:INTF:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662538560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.st_TMO_ILK_Upper</Name>
-            <Comment> TMO vacuum interface</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ST_EXT_ILK</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K4:SOMS:GCC:1:ILK_UPPER</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662539744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.st_TMO_ILK_Lower</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ST_EXT_ILK</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: MR1K4:SOMS:GCC:1:ILK_LOWER</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662539808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_PC1K1_INTF_GCC_1</Name>
-            <Comment> AD Interface</Comment>
-            <BitSize>1184</BitSize>
-            <BaseType>FB_EXT_TREATY_GAUGE</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value> pv: PC1K1:INTF:GCC:1 </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662539872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_EM1K0_GMD_GCC_10_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662541056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_AT1K0_GAS_GCC_10_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662634944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_AT1K0_GAS_GCC_140_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662728832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_EM2K0_XGMD_GCC_10_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662822720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_VAC_INTF.fb_EM2K0_XGMD_GCC_90_reader</Name>
-            <BitSize>93888</BitSize>
-            <BaseType Namespace="LCLS_Vacuum">FB_TGCC_ADS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>662916608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputK0</Name>
-            <Comment> ***************************
- Hardware Fast fault outputs
- ***************************
- K0/SXR upstream specific faults</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: @(PREFIX)FFO:01
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663010496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputK2</Name>
-            <Comment> K2/RIX specific faults</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: @(PREFIX)FFO:02
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663275392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputK3</Name>
-            <Comment> K3/TXI specific faults</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: @(PREFIX)FFO:03
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663540288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputK4</Name>
-            <Comment> K4/TMO specific faults</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: @(PREFIX)FFO:04
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663805184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputAll</Name>
-            <Comment> Fault aggregator for combined beamline</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO (EL2202)]^Channel 1^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>664070080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_FastFaultOutputINTF</Name>
-            <Comment> Dummy FFO for valves not yet allowed to open. To be removed when proper interfaces to TXI and RIX vacuum are implemented.</Comment>
-            <BitSize>264896</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.92.73.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: @(PREFIX)FF1A
-</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>664599872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Variables.g_fbArbiter1</Name>
-            <Comment> *******
- Arbiter
- *******</Comment>
-            <BitSize>474624</BitSize>
-            <BaseType Namespace="PMPS">FB_Arbiter</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-     pv: @(PREFIX)Arb:01
-</Value>
-              </Property>
-              <Property>
-                <Name>old_input_assignments</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>664864768</BitOffs>
+            <BitOffs>650913792</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">20</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>1</ContextId>
-          <ByteSize>83361792</ByteSize>
+          <ByteSize>82116608</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -48213,15 +48290,15 @@ pv: @(PREFIX)RESET:FF4
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-01-12T10:10:40</Value>
+          <Value>2024-01-12T11:19:38</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>589824</Value>
+          <Value>643072</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>80887808</Value>
+          <Value>80932864</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
## Description
Resolved naming collision and hard coded prefix for the global variable: `g_FastFaultOutput2` 

### New 
https://github.com/pcdshub/lcls-plc-kfe-vac/blob/929188b560e1643652ab2c7dd5de242167507fcf/plc/plc-kfe-vac/plc_kfe_vac/GVLs/GVL_Variables.TcGVL#L48-L52

### Old
https://github.com/pcdshub/lcls-plc-kfe-vac/blob/dddf84bed5197c77a032126085ad3f63f9685404/plc/plc-kfe-vac/plc_kfe_vac/GVLs/GVL_Variables.TcGVL#L48-L52

### Linked PRs
- https://github.com/pcdshub/pmps-ui/pull/93 implements the config update needed to render in PMPS Diagnostics

## Motivation and Context
ACR called to resolve a fault induced by the failure of the fast shut gauge TV2K0-VFS-1; after this was resolved from the ECS end there were remaining faults on the ACR operator end that did not propagate to the PMPS Diagnostics Screen. This did not allow the convenient reset  of clicking whatever button we use (TODO josh you should probably get better understanding and verbiage for this). This required @ghalym to login to `plcprog` to get on the device to resolve; in doing so she discovered this naming collision that this PR resolves.

## How Has This Been Tested?
- [ ] Close valve, see fault generated

## Where Has This Been Documented?
Good question

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive comments
- [ ] Test suite passes locally
- [x] Libraries are set to fixed versions and not ``Always Newest``
- [x] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
